### PR TITLE
Add profile picture in user model

### DIFF
--- a/insalan/user/admin.py
+++ b/insalan/user/admin.py
@@ -3,5 +3,12 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from .models import User
 
-admin.site.register(User, UserAdmin)
+class CustomUserAdmin(UserAdmin):
+    fieldsets = UserAdmin.fieldsets + (
+        ("Image", {
+            'fields': ('image',),
+        }),
+    )
+
+admin.site.register(User, CustomUserAdmin)
 # Register your models here.

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -17,7 +17,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
-
+from django.core.validators import FileExtensionValidator
 
 class UserManager(BaseUserManager):
     """
@@ -39,6 +39,7 @@ class UserManager(BaseUserManager):
         user = self.model(
             email=self.normalize_email(email),
             username=username,
+            image=None,
             date_joined=timezone.make_aware(datetime.now()),
             **extra_fields
         )
@@ -79,6 +80,16 @@ class User(AbstractUser, PermissionsMixin):
 
     USERNAME_FIELD = "username"
     EMAIL_FIELD = "email"
+
+    image = models.FileField(
+        verbose_name=_("photo de profil"),
+        blank=True,
+        null=True,
+        upload_to="profile-pictures",
+        validators=[
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg"])
+        ],
+    )
 
     email = models.EmailField(
         verbose_name=_("Courriel"), max_length=255, unique=True, blank=False

--- a/insalan/user/serializers.py
+++ b/insalan/user/serializers.py
@@ -7,6 +7,8 @@ from django.contrib.auth.password_validation import validate_password
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
+from django.core.validators import FileExtensionValidator
+
 
 from .models import User, UserMailer
 
@@ -35,6 +37,12 @@ class UserRegisterSerializer(serializers.ModelSerializer):
     first_name = serializers.CharField(max_length=50, required=False)
     last_name = serializers.CharField(max_length=50, required=False)
     password_validation = serializers.CharField(write_only=True, required=True)
+    image = serializers.FileField(
+        required=False,
+        validators=[
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg"])
+        ],
+    )
 
     class Meta:
         """Meta class, used to set parameters"""
@@ -48,6 +56,7 @@ class UserRegisterSerializer(serializers.ModelSerializer):
             "is_staff",
             "is_superuser",
             "email",
+            "image",
             "email_active",
             "password",
             "password_validation",


### PR DESCRIPTION
Add profile picture handling in backend in the user model.
On user creation, image is None and can currently only be changed in django admin panel.

The endpoint to edit our profile picture should be added later. (can be in the same batch as #59 )