### PR TITLE
Added checkbox to set 'email_active' user field

### DIFF
--- a/insalan/user/admin.py
+++ b/insalan/user/admin.py
@@ -8,6 +8,9 @@ class CustomUserAdmin(UserAdmin):
         ("Image", {
             'fields': ('image',),
         }),
+        ("Email options", {
+            'fields': ('email_active',),
+        })
     )
 
 admin.site.register(User, CustomUserAdmin)


### PR DESCRIPTION
This PR simply adds a toggle in the admin panel for users.

This allows to create valid users without setting up the mailer.
Without this field set to 'true', it's impossible to log in on the front-end.