### PR TITLE
Adding validator on content in the cms module

### DIFF
--- a/insalan/cms/models.py
+++ b/insalan/cms/models.py
@@ -2,8 +2,7 @@ from djongo import models
 from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
 import re
-import logging
-logger = logging.getLogger("cms")
+
 def constant_definition_validator(content: str):
     """
     validator to ensure that any used constant in content is defined

--- a/insalan/cms/models.py
+++ b/insalan/cms/models.py
@@ -15,7 +15,7 @@ def constant_definition_validator(content: str):
 
     if len(excess_constants) > 0:
         raise ValidationError(
-                _(f"des constantes non définies sont utilisées: {', '.join(sorted(excess_constants))}"))
+                _(f"Des constantes non définies sont utilisées: {', '.join(sorted(excess_constants))}"))
 
 class Content(models.Model):
     """

--- a/insalan/cms/serializers.py
+++ b/insalan/cms/serializers.py
@@ -6,7 +6,7 @@ class ContentSerializer(serializers.ModelSerializer):
     """ Serializer for a content in the cms """
     class Meta:
         model = Content
-        fields = ["section", "content"]
+        fields = ["name", "content"]
 
 class ConstantSerializer(serializers.ModelSerializer):
     class Meta:

--- a/insalan/cms/tests.py
+++ b/insalan/cms/tests.py
@@ -1,3 +1,25 @@
 from django.test import TestCase
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
-# Create your tests here.
+from insalan.cms.models import ( 
+    Constant,
+    Content
+)
+
+
+class ContentTestCase(TestCase):
+    def test_content_with_constants(self):
+        """ test that we can create a content using constant """
+        Constant.objects.create(name="a", value="je suis la valeur a")
+        Constant.objects.create(name="b", value="je suis la valeur b")
+        Content.objects.create(name="content_a", content="j'appelle la constante ${a} et la constante ${b}")
+
+    def test_content_with_unknow_constants(self):
+        Constant.objects.create(name="a", value="je suis la valeur a")
+        Content.objects.create(name="content", content="je suis ${a} mais aussi une variable ${random}")
+        self.assertRaises(ValidationError)
+
+    def test_display_undefined_constant_list(self):
+        Content.objects.create(name="content", content="je test ${inconnue} mais aussi une variable ${random}")
+        self.assertRaisesMessage(ValidationError, _("des constantes non définies sont utilisées: inconnue, random"))

--- a/insalan/cms/tests.py
+++ b/insalan/cms/tests.py
@@ -22,4 +22,4 @@ class ContentTestCase(TestCase):
 
     def test_display_undefined_constant_list(self):
         Content.objects.create(name="content", content="je test ${inconnue} mais aussi une variable ${random}")
-        self.assertRaisesMessage(ValidationError, _("des constantes non définies sont utilisées: inconnue, random"))
+        self.assertRaisesMessage(ValidationError, _("Des constantes non définies sont utilisées: inconnue, random"))

--- a/insalan/cms/views.py
+++ b/insalan/cms/views.py
@@ -13,7 +13,7 @@ class ContentFetch(generics.ListAPIView):
 
     serializer_class = serializers.ContentSerializer
     def get_queryset(self):
-        return Content.objects.filter(name=self.kwargs["section"])
+        return Content.objects.filter(name=self.kwargs["name"])
 
 class ConstantFetch(generics.ListAPIView):
     pagination_class = None

--- a/insalan/cms/views.py
+++ b/insalan/cms/views.py
@@ -13,7 +13,7 @@ class ContentFetch(generics.ListAPIView):
 
     serializer_class = serializers.ContentSerializer
     def get_queryset(self):
-        return Content.objects.filter(section=self.kwargs["section"])
+        return Content.objects.filter(name=self.kwargs["section"])
 
 class ConstantFetch(generics.ListAPIView):
     pagination_class = None


### PR DESCRIPTION
This PR adds the ability to use the constant objects defined in the Django admin panel in the content, by using a special syntax `${CONSTANT_NAME}`.  A validator is used to check whether a constant is used in a constant but hasn't been defined.