### PR TITLE
Use the is_announced field

### DIFF
--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -33,7 +33,7 @@ admin.site.register(Game, GameAdmin)
 class TournamentAdmin(admin.ModelAdmin):
     """Admin handler for Tournaments"""
 
-    list_display = ("id", "name", "event", "game")
+    list_display = ("id", "name", "event", "game", "is_announced")
     search_fields = ["name", "event", "game"]
 
 

--- a/insalan/tournament/tests.py
+++ b/insalan/tournament/tests.py
@@ -893,10 +893,11 @@ class TournamentFullDerefEndpoint(TestCase):
             description="This is a test",
             year=2021,
             month=12,
-            ongoing=False,
+            ongoing=False
         )
         tourneyobj_one = Tournament.objects.create(
-            event=evobj, name="Test Tournament", rules="have fun!", game=game_obj
+            event=evobj, name="Test Tournament", rules="have fun!", game=game_obj,
+            is_announced=True
         )
         team_one = Team.objects.create(name="Team One", tournament=tourneyobj_one)
         Player.objects.create(user=uobj_one, team=team_one)
@@ -939,6 +940,46 @@ class TournamentFullDerefEndpoint(TestCase):
             },
         )
 
+    def test_not_announced(self):
+        """Test a simple example"""
+        uobj_one = User.objects.create(
+            username="test_user_one", email="one@example.com"
+        )
+        uobj_two = User.objects.create(
+            username="test_user_two", email="two@example.com"
+        )
+        uobj_three = User.objects.create(
+            username="test_user_three", email="three@example.com"
+        )
+
+        game_obj = Game.objects.create(name="Test Game", short_name="TFG")
+
+        evobj = Event.objects.create(
+            name="Test Event",
+            description="This is a test",
+            year=2021,
+            month=12,
+            ongoing=False
+        )
+        tourneyobj_one = Tournament.objects.create(
+            event=evobj, name="Test Tournament", rules="have fun!", game=game_obj,
+            is_announced=False
+        )
+        team_one = Team.objects.create(name="Team One", tournament=tourneyobj_one)
+        Player.objects.create(user=uobj_one, team=team_one)
+        Player.objects.create(user=uobj_two, team=team_one)
+        Manager.objects.create(user=uobj_three, team=team_one)
+
+        request = self.client.get(
+            reverse("tournament/details-full", args=[tourneyobj_one.id]), format="json"
+        )
+        self.assertEqual(request.status_code, 200)
+        self.assertEqual(
+            request.data,
+            {
+                "id": tourneyobj_one.id,
+            }     
+        )
 
 class EventDerefAndGroupingEndpoints(TestCase):
     """Test endpoints for dereferencing/fetching grouped events"""

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -143,9 +143,10 @@ class TournamentDetailsFull(APIView):
             raise Http404
         if len(tourneys) > 1:
             return Response("", status=status.HTTP_400_BAD_REQUEST)
-
         tourney = tourneys[0]
-
+        #if the tournament hasn't been yet announced, we don't want to return details of it
+        if not tourney.is_announced:
+            return Response({"id": primary_key}, status=status.HTTP_200_OK)
         tourney_serialized = serializers.TournamentSerializer(
             tourney, context={"request": request}
         ).data


### PR DESCRIPTION
If this field is set to false, the `/tournament/tournament/<id>/full` returns only the requested id. This allows the creation of tournaments before the announcement date.