### PR TITLE
🏷️ Added a release of the manual on tags

### DIFF
--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -2,7 +2,7 @@ on:
   # Creating a release requires a tag
   push:
     tags:
-      "manuel*"
+      "*"
     paths:
       - 'docs/manuel/**'
       - '.github/workflows/manual.yaml'
@@ -32,7 +32,8 @@ jobs:
       - name: Build the book
         run: |
           mdbook build
-          tar zcvf manuel.tar.gz book
+          mv book manuel-backend-${{ env.sha_short }}
+          tar zcvf manuel.tar.gz manuel-backend-${{ env.sha_short }}
         working-directory: ${{ env.book-dir }}
 
       # Create a release

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -1,8 +1,12 @@
 on:
+  # Creating a release requires a tag
   push:
+    tags:
+      "manuel*"
     paths:
       - 'docs/manuel/**'
       - '.github/workflows/manual.yaml'
+
 jobs:
   build-manual:
     runs-on: ubuntu-22.04
@@ -26,12 +30,14 @@ jobs:
 
       # Build the book
       - name: Build the book
-        run: mdbook build
+        run: |
+          mdbook build
+          tar zcvf manuel.tar.gz book
         working-directory: ${{ env.book-dir }}
 
-      # Package artifact
-      - name: Package artifact
-        uses: actions/upload-artifact@v3
+      # Create a release
+      - name: Create a release
+        uses: softprops/action-gh-release@v1
         with:
-          name: manuel-backend-${{ env.branch }}-${{ env.sha_short }}
-          path: ${{ env.book-dir }}/book
+          files: ${{ env.book-dir }}/manuel.tar.gz
+


### PR DESCRIPTION
We require a tag because creating a github release requires a tag.

The pipeline changed the file name to be able to easily pull the manual from https://github.com/InsaLan/backend-insalan.fr/releases/latest/download/manuel.tar.gz