### PR TITLE
 fix #80

### DIFF
--- a/insalan/urls.py
+++ b/insalan/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     path("v1/admin/", admin.site.urls)
 
 ]
-if not int(getenv("DEV")):
+if not int(getenv("DEV", "1")):
     urlpatterns.insert(1,
         path("v1/admin/login/", RedirectView.as_view(url=f"{getenv('HTTP_PROTOCOL')}://{getenv('WEBSITE_HOST')}/register")))
 

--- a/insalan/urls.py
+++ b/insalan/urls.py
@@ -20,7 +20,6 @@ from rest_framework import routers
 
 from os import getenv
 from insalan.langate import views as langate_views
-
 router = routers.DefaultRouter()
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
@@ -32,10 +31,12 @@ urlpatterns = [
     path("v1/tickets/", include("insalan.tickets.urls")),
     path("v1/langate/authenticate", langate_views.LangateUserView.as_view()),
     path("v1/content/", include("insalan.cms.urls")),
-    #path("v1/api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    path("v1/admin/login/", RedirectView.as_view(url=f"{getenv('HTTP_PROTOCOL')}://{getenv('WEBSITE_HOST')}/register")),
-    path("v1/admin/", admin.site.urls),
+    path("v1/admin/", admin.site.urls)
+
 ]
+if not int(getenv("DEV")):
+    urlpatterns.insert(1,
+        path("v1/admin/login/", RedirectView.as_view(url=f"{getenv('HTTP_PROTOCOL')}://{getenv('WEBSITE_HOST')}/register")))
 
 # Set admin site url correctly for the admin panel
 admin.site.site_url = "/v1/"

--- a/insalan/urls.py
+++ b/insalan/urls.py
@@ -14,11 +14,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+from django.views.generic.base import RedirectView
 from django.urls import include, path
-
 from rest_framework import routers
 
-
+from os import getenv
 from insalan.langate import views as langate_views
 
 router = routers.DefaultRouter()
@@ -33,6 +33,7 @@ urlpatterns = [
     path("v1/langate/authenticate", langate_views.LangateUserView.as_view()),
     path("v1/content/", include("insalan.cms.urls")),
     #path("v1/api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    path("v1/admin/login/", RedirectView.as_view(url=f"{getenv('HTTP_PROTOCOL')}://{getenv('WEBSITE_HOST')}/register")),
     path("v1/admin/", admin.site.urls),
 ]
 


### PR DESCRIPTION
Redirects `/v1/admin/login` to the frontend login page, in order to fix #80. The next step is to add a button on the frontend side to go to django admin interface. 