### PR TITLE
Add missing fields for tournaments

### DIFF
--- a/insalan/payment/models.py
+++ b/insalan/payment/models.py
@@ -165,6 +165,7 @@ class Transaction(models.Model):
         for pid, grouper in itertools.groupby(data["products"]):
             # Validate that the products can be bought
             if not pid.can_be_bought_now():
+                transaction.delete()
                 raise ValidationError(
                     {
                         "error": _("Le produit %(id)s est actuellement indisponible")
@@ -172,6 +173,7 @@ class Transaction(models.Model):
                     }
                 )
             if pid.associated_tournament and not pid.associated_tournament.is_announced:
+                transaction.delete()
                 raise ValidationError(
                     {
                         "error": _("Le tournoi %(id)s est actuellement indisponible")

--- a/insalan/payment/models.py
+++ b/insalan/payment/models.py
@@ -313,7 +313,7 @@ class Transaction(models.Model):
                 logger.warning("Attempted to validate %s in invalid state", self.id)
             return
 
-        self.payment_status = TransactionStatus.SUCCEDED
+        self.payment_status = TransactionStatus.SUCCEEDED
         self.last_modification_date = timezone.make_aware(datetime.now())
         self.save()
         logger.info("Transaction %s succeeded", self.id)

--- a/insalan/payment/tokens.py
+++ b/insalan/payment/tokens.py
@@ -75,6 +75,10 @@ class Token:
                 _("Impossible de rafraîchir le jeton HelloAsso")
             ) from err
 
+        result = request.json()
+        if "error" in result:
+            raise RuntimeError(_("Impossible de rafraichir le jeton HelloAsso: %s") % result["error_description"])
+
         self.assign_token_data(request.json())
 
     def assign_token_data(self, data):

--- a/insalan/payment/views.py
+++ b/insalan/payment/views.py
@@ -112,7 +112,7 @@ class Notifications(APIView):
             pay_obj = pay_objs[0]
             if pay_obj is not None and pay_obj.transaction != trans_obj:
                 logger.error(
-                    "Mismatch! Payment %d is known to belong to transaction %s but HA metadata says %s",
+                    "Mismatch! Payment %s is known to belong to transaction %s but HA metadata says %s",
                     pay_id,
                     trans_obj.id,
                     pay_obj.transaction.id,
@@ -120,7 +120,7 @@ class Notifications(APIView):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
             if pay_obj is not None and trans_obj.order_id != int(data["order"]["id"]):
                 logger.error(
-                    "Mismatch! Payment %d is known to belong to transaction %s but HA data says %s",
+                    "Mismatch! Payment %s is known to belong to transaction %s but HA data says %s",
                     pay_id,
                     trans_obj.order_id,
                     data["order"]["id"],
@@ -128,7 +128,7 @@ class Notifications(APIView):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
             if pay_obj is None:
                 logger.warning(
-                    "Validating transaction %s based on payment %d to be generated later",
+                    "Validating transaction %s based on payment %s to be generated later",
                     trans_obj.id,
                     pay_id,
                 )
@@ -148,9 +148,7 @@ class Notifications(APIView):
 
             else:
                 logger.warning(
-                    "Payment %d shows status %s unknown or already assigned",
-                    pay_id,
-                    data["state"],
+                    "Payment %s shows status %s unknown or already assigned", pay_id, data["state"]
                 )
 
         return Response(status=status.HTTP_200_OK)

--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -332,7 +332,7 @@ class Tournament(models.Model):
     def get_rules(self) -> str:
         """Return the raw tournament rules"""
         return self.rules
-    
+
     def get_maxTeam(self) -> int:
         """Return the max number of teams"""
         return self.maxTeam
@@ -423,7 +423,7 @@ class Team(models.Model):
         Retrieve the user identifiers of all managers
         """
         return self.get_managers().values_list("id", flat=True)
-    
+
     def get_password(self) -> str:
         """Return team password"""
         return self.password

--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -348,6 +348,13 @@ class Team(models.Model):
     validated = models.BooleanField(
         default=False, blank=True, verbose_name=_("Équipe validée")
     )
+    password = models.CharField(
+        max_length=20,
+        validators=[MinLengthValidator(8)],
+        null=False,
+        verbose_name=_("Mot de passe de l'équipe"),
+        default='',
+    )
 
     class Meta:
         """Meta Options"""
@@ -401,6 +408,10 @@ class Team(models.Model):
         Retrieve the user identifiers of all managers
         """
         return self.get_managers().values_list("user_id", flat=True)
+    
+    def get_password(self) -> str:
+        """Return team password"""
+        return self.password
 
     def refresh_validation(self):
         """Refreshes the validation state of a tournament"""
@@ -478,6 +489,13 @@ class Player(models.Model):
         blank=True,
         default=None,
     )
+    pseudo = models.CharField(
+        max_length=42,
+        validators=[MinLengthValidator(1)],
+        null=False,
+        verbose_name=_("Pseudo"),
+        default='',
+    )
 
     def __str__(self) -> str:
         """Format this player registration to a str"""
@@ -490,6 +508,10 @@ class Player(models.Model):
     def get_team(self):
         """Return the Team object of the current team"""
         return self.team
+
+    def get_pseudo(self) -> str:
+        """Return the pseudo of the player"""
+        return self.pseudo
 
     def clean(self):
         """
@@ -548,6 +570,13 @@ class Manager(models.Model):
         blank=True,
         default=None,
     )
+    pseudo = models.CharField(
+        max_length=42,
+        validators=[MinLengthValidator(1)],
+        null=False,
+        verbose_name=_("Pseudo"),
+        default='',
+    )
 
     class Meta:
         """Meta Options"""
@@ -571,6 +600,10 @@ class Manager(models.Model):
     def get_team(self):
         """Return the Team object of the current team"""
         return self.team
+    
+    def get_pseudo(self) -> str:
+        """Return the pseudo of the player"""
+        return self.pseudo
 
 
 # vim: set cc=80 tw=80:

--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -239,6 +239,12 @@ class Tournament(models.Model):
         verbose_name=_("Produit joueur"),
         on_delete=models.SET_NULL,
     )
+    maxTeam = models.IntegerField(
+        default=0,
+        null=False,
+        verbose_name=_("Nombre maximal d'équipe"),
+        validators=[MinValueValidator(0)],
+    )
 
     class Meta:
         """Meta options"""
@@ -324,6 +330,10 @@ class Tournament(models.Model):
     def get_rules(self) -> str:
         """Return the raw tournament rules"""
         return self.rules
+    
+    def get_maxTeam(self) -> int:
+        """Return the max number of teams"""
+        return self.maxTeam
 
 
 class Team(models.Model):

--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -489,7 +489,6 @@ class Player(models.Model):
         User,
         on_delete=models.CASCADE,
         verbose_name=_("Utilisateur⋅ice"),
-        #validators=[player_manager_user_unique_validator,unique_event_registration],
     )
     team = models.ForeignKey(
         "tournament.Team",
@@ -548,28 +547,6 @@ class Player(models.Model):
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")
             )
 
-        # event = self.get_team().get_tournament().get_event()
-        # raise ValidationError("test2")
-
-        # if (
-        #     len(
-        #         [
-        #             player.user
-        #             for players in [
-        #                 team.get_players()
-        #                 for teams in [
-        #                     trnm.get_teams() for trnm in event.get_tournaments()
-        #                 ]
-        #                 for team in teams
-        #             ]
-        #             for player in players
-        #             if player.user == self.user
-        #         ]
-        #     )
-        #     > 0
-        # ):
-        #     raise ValidationError(_("Joueur⋅euse déjà inscrit⋅e pour cet évènement"))
-
 
 class Manager(models.Model):
     """
@@ -580,7 +557,6 @@ class Manager(models.Model):
         User,
         verbose_name=_("Utilisateur⋅ice"),
         on_delete=models.CASCADE,
-        #validators=[player_manager_user_unique_validator,unique_event_registration],
     )
     team = models.ForeignKey(
         "tournament.Team",
@@ -638,26 +614,5 @@ class Manager(models.Model):
             raise ValidationError(
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")
             )
-
-        # event = self.get_team().get_tournament().get_event()
-
-        # if (
-        #     len(
-        #         [
-        #             player.user
-        #             for players in [
-        #                 team.get_players()
-        #                 for teams in [
-        #                     trnm.get_teams() for trnm in event.get_tournaments()
-        #                 ]
-        #                 for team in teams
-        #             ]
-        #             for player in players
-        #             if player.user == self.user
-        #         ]
-        #     )
-        #     > 1
-        # ):
-        #     raise ValidationError(_("Manageur⋅euse déjà inscrit⋅e pour cet évènement"))
 
 # vim: set cc=80 tw=80:

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -89,14 +89,14 @@ class TeamSerializer(serializers.ModelSerializer):
         extra_kwargs = {"password" : {"write_only": True}}
 
     def validate(self, data):
-        for user in data["get_players_id"] + data["get_managers_id"]:
+        for user in data.pop("get_players_id", []) + data.pop("get_managers_id", []):
             event = Event.objects.get(tournament=data["tournament"])
             if not unique_event_registration(user,event):
                 raise serializers.ValidationError(
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")
             )
         
-        if len(data["players_pseudos"]) != len(data["get_players_id"]):
+        if len(data.pop("players_pseudos", [])) != len(data.pop("get_players_id", [])):
             raise serializers.ValidationError(_("Il manque des pseudos de joueur⋅euses"))
 
         return data

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -95,12 +95,12 @@ class TeamSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")
             )
-        
+
         if len(data.get("players_pseudos", [])) != len(data.get("get_players_id", [])):
             raise serializers.ValidationError(_("Il manque des pseudos de joueur⋅euses"))
 
         return data
-            
+
 
     def create(self, validated_data):
         """Create a Team from input data"""
@@ -192,7 +192,7 @@ class ManagerSerializer(serializers.ModelSerializer):
 
         model = Manager
         fields = "__all__"
-    
+
     def validate(self, data):
         event = Event.objects.get(tournament__team=data["team"])
         if not unique_event_registration(data["user"],event):

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -6,7 +6,7 @@
 
 from rest_framework import serializers
 
-from .models import Event, Tournament, Game, Team, Player, Manager
+from .models import Event, Tournament, Game, Team, Player, Manager, unique_registration
 from insalan.user.models import User
 from django.utils.translation import gettext_lazy as _
 
@@ -72,12 +72,11 @@ class TournamentSerializer(serializers.ModelSerializer):
             return {"id": ret["id"], "is_announced": False}
 
 
-
 class TeamSerializer(serializers.ModelSerializer):
     """Serializer class for Teams"""
 
-    players = serializers.ListField(required=False, source="get_players_id")
-    managers = serializers.ListField(required=False, source="get_managers_id")
+    players = serializers.ListField(required=False, source="get_players_id", validators=[unique_registration])
+    managers = serializers.ListField(required=False, source="get_managers_id", validators=[unique_registration])
     password = serializers.CharField(write_only=True)
     players_pseudos = serializers.ListField(required=False, write_only=True)
     managers_pseudos = serializers.ListField(required=False, write_only=True)

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -63,6 +63,15 @@ class TournamentSerializer(serializers.ModelSerializer):
         )
         fields = "__all__"
 
+    def to_representation(self, instance):
+        """Remove all fields except id and is_announced when is_announced is False"""
+        ret = super().to_representation(instance)
+        if ret["is_announced"]:
+            return ret
+        else:
+            return {"id": ret["id"], "is_announced": False}
+
+
 
 class TeamSerializer(serializers.ModelSerializer):
     """Serializer class for Teams"""

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -89,14 +89,14 @@ class TeamSerializer(serializers.ModelSerializer):
         extra_kwargs = {"password" : {"write_only": True}}
 
     def validate(self, data):
-        for user in data.pop("get_players_id", []) + data.pop("get_managers_id", []):
+        for user in data.get("get_players_id", []) + data.get("get_managers_id", []):
             event = Event.objects.get(tournament=data["tournament"])
             if not unique_event_registration(user,event):
                 raise serializers.ValidationError(
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")
             )
         
-        if len(data.pop("players_pseudos", [])) != len(data.pop("get_players_id", [])):
+        if len(data.get("players_pseudos", [])) != len(data.get("get_players_id", [])):
             raise serializers.ValidationError(_("Il manque des pseudos de joueur⋅euses"))
 
         return data
@@ -111,7 +111,7 @@ class TeamSerializer(serializers.ModelSerializer):
         players_pseudos = validated_data.pop("players_pseudos", [])
 
         validated_data["password"] = make_password(validated_data["password"])
-        team_obj = Team(**validated_data)
+        team_obj = Team.objects.create(**validated_data)
 
         for player, pseudo in zip(players,players_pseudos):
             user_obj = User.objects.get(id=player)
@@ -120,8 +120,6 @@ class TeamSerializer(serializers.ModelSerializer):
         for manager in managers:
             user_obj = User.objects.get(id=manager)
             Manager.objects.create(user=user_obj, team=team_obj)
-
-        team_obj.save()
 
         return team_obj
 

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -171,7 +171,6 @@ class PlayerSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         event = Event.objects.get(tournament__team=data["team"])
-        raise serializers.ValidationError(data["user"])
         if not unique_event_registration(data["user"],event):
             raise serializers.ValidationError(
                 _("Utilisateur⋅rice déjà inscrit⋅e dans un tournoi de cet évènement")

--- a/insalan/tournament/tests.py
+++ b/insalan/tournament/tests.py
@@ -1302,7 +1302,9 @@ class ManagerTestCase(TestCase):
             last_name="Nya",
         )
 
-        Manager.objects.create(user=fella, team=team_one).full_clean()
+        manager = Manager(user=fella, team=team_one)
+        manager.full_clean()
+        manager.save()
         self.assertRaises(
             IntegrityError, Manager.objects.create, user=fella, team=team_one
         )
@@ -1350,14 +1352,17 @@ class ManagerTestCase(TestCase):
             last_name="Nya",
         )
 
-        Manager.objects.create(user=fella, team=team_one).full_clean()
+        man = Manager(user=fella, team=team_one)
+        man.full_clean()
+        man.save()
         man2 = Manager.objects.create(user=fella, team=team_two)
 
         self.assertRaises(ValidationError, man2.full_clean)
 
 
     def test_one_manager_many_teams_diff_event_diff_tournament_diff_team(self):
-        """Test the collision of duplicate managers"""
+        """Test the non collision of duplicate managers in different teams
+        of different tournament of different event"""
         # Basic setup for a one-tournamnent game event
         event = Event.objects.create(
             name="InsaLan Test", year=2023, month=8, description=""
@@ -1379,9 +1384,11 @@ class ManagerTestCase(TestCase):
             last_name="Nya",
         )
 
-        Manager.objects.create(user=fella, team=team_one).full_clean()
-        man2 = Manager.objects.create(user=fella, team=team_two)
-        self.assertRaises(ValidationError, man2.full_clean)
+        man = Manager(user=fella, team=team_one)
+        man.full_clean()
+        man.save()
+        man2 = Manager(user=fella, team=team_two)
+        man2.full_clean()
 
     def test_manager_team_deletion(self):
         """Verify the behaviour of a Manager when their team gets deleted"""

--- a/insalan/tournament/tests.py
+++ b/insalan/tournament/tests.py
@@ -835,7 +835,7 @@ class PlayerTestCase(TestCase):
 
         # Try and register them in the same team
         player = Player.objects.create(user=user, team=team_two, pseudo="pseudo")
-        self.assertRaises(ValidationError, player.full_clean())
+        self.assertRaises(ValidationError, player.full_clean)
 
     def test_get_player_team_not_none(self):
         """Check that a player gives a non null team"""
@@ -1181,7 +1181,6 @@ class EventDerefAndGroupingEndpoints(TestCase):
                     "manager_price_online": "0.00",
                     "manager_price_onsite": "0.00",
                     "cashprizes": [],
-                    "max_team": 0,
                     "game": gobj.id,
                     "manager_online_product": tourney.manager_online_product.id,
                     "player_online_product": tourney.player_online_product.id,
@@ -1329,7 +1328,7 @@ class ManagerTestCase(TestCase):
 
         man2 = Manager.objects.create(user=fella, team=team_two)
 
-        self.assertRaises(ValidationError, man2.full_clean())
+        self.assertRaises(ValidationError, man2.full_clean)
 
     def test_one_manager_many_teams_same_event_diff_tournament_diff_team(self):
         """Test the collision of duplicate managers"""
@@ -1354,7 +1353,7 @@ class ManagerTestCase(TestCase):
         Manager.objects.create(user=fella, team=team_one).full_clean()
         man2 = Manager.objects.create(user=fella, team=team_two)
 
-        self.assertRaises(ValidationError, man2.full_clean())
+        self.assertRaises(ValidationError, man2.full_clean)
 
 
     def test_one_manager_many_teams_diff_event_diff_tournament_diff_team(self):
@@ -1382,7 +1381,7 @@ class ManagerTestCase(TestCase):
 
         Manager.objects.create(user=fella, team=team_one).full_clean()
         man2 = Manager.objects.create(user=fella, team=team_two)
-        self.assertRaises(ValidationError, man2.full_clean())
+        self.assertRaises(ValidationError, man2.full_clean)
 
     def test_manager_team_deletion(self):
         """Verify the behaviour of a Manager when their team gets deleted"""
@@ -1502,7 +1501,7 @@ class TournamentTeamEndpoints(TestCase):
             {
                 "name": "Les emails valides",
                 "tournament": trnm.id,
-                "password":"Password123!"
+                "password": "password",
             },
             format="json",
         )
@@ -1539,7 +1538,7 @@ class TournamentTeamEndpoints(TestCase):
             "/v1/tournament/player/",
             {
                 "team": team.id,
-                "password": "Password123!",
+                "password": "password",
                 "pseudo":"pseudo",
             },
             format="json",
@@ -1552,7 +1551,7 @@ class TournamentTeamEndpoints(TestCase):
             "/v1/tournament/manager/",
             {
                 "team": team.id,
-                "password":"Password123!",
+                "password":"password",
             },
             format="json",
         )

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -14,6 +14,7 @@ from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
 from rest_framework.serializers import PrimaryKeyRelatedField
 from rest_framework.views import APIView
+from django.http import QueryDict
 
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
@@ -174,7 +175,7 @@ class TournamentDetailsFull(APIView):
 
                 # Dereference players/managers to pseudo
                 team_preser["players"] = [
-                    Player.objects.get(id=pid).pseudo for pid in team_preser["players"]
+                    {"user": Player.objects.get(id=pid).as_user().username, "pseudo": Player.objects.get(id=pid).pseudo} for pid in team_preser["players"]
                 ]
                 team_preser["managers"] = [
                     Manager.objects.get(id=pid).as_user().username for pid in team_preser["managers"]
@@ -279,8 +280,10 @@ class PlayerRegistrationList(generics.ListCreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
+        # make the data dict mutable in the case of immutable QueryDict form django test client
+        if type(data) == QueryDict:
+            data._mutable = True
         data["user"] = user.id
-        data["payment"] = PaymentStatus.NOT_PAID
 
         return super().post(request, *args, **kwargs)
 
@@ -357,8 +360,10 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
+        # make the data dict mutable in the case of immutable QueryDict form django test client
+        if type(data) == QueryDict:
+            data._mutable = True
         data["user"] = user.id
-        data["payment"] = PaymentStatus.NOT_PAID
 
         return super().post(request, *args, **kwargs)
 

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -176,12 +176,12 @@ class TournamentDetailsFull(APIView):
             ).data
             del team_preser["tournament"]
 
-            # Dereference players/managers to users (username)
+            # Dereference players/managers to pseudo
             team_preser["players"] = [
-                User.objects.get(id=pid).username for pid in team_preser["players"]
+                Player.objects.get(id=pid).pseudo for pid in team_preser["players"]
             ]
             team_preser["managers"] = [
-                User.objects.get(id=pid).username for pid in team_preser["managers"]
+                Player.objects.get(id=pid).pseudo for pid in team_preser["managers"]
             ]
 
             teams_serialized.append(team_preser)

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -274,7 +274,7 @@ class PlayerRegistrationList(generics.ListCreateAPIView):
                 }
             )
         
-        if check_password(data["password"], Team.objects.get(pk=data["team"]).get_password()):
+        if not check_password(data["password"], Team.objects.get(pk=data["team"]).get_password()):
             return Response(
                 { "password": _("Mot de passe invalide.")},
                 status=status.HTTP_400_BAD_REQUEST
@@ -354,7 +354,7 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
                 }
             )
 
-        if check_password(data["password"], Team.objects.get(pk=data["team"]).get_password()):
+        if not check_password(data["password"], Team.objects.get(pk=data["team"]).get_password()):
             return Response(
                 { "password": _("Mot de passe invalide.")},
                 status=status.HTTP_400_BAD_REQUEST

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -146,9 +146,7 @@ class TournamentDetailsFull(APIView):
         if len(tourneys) > 1:
             return Response("", status=status.HTTP_400_BAD_REQUEST)
         tourney = tourneys[0]
-        # if the tournament hasn't been yet announced, we don't want to return details of it
-        # if not tourney.is_announced:
-            # return Response({"id": primary_key}, status=status.HTTP_200_OK)
+        
         tourney_serialized = serializers.TournamentSerializer(
             tourney, context={"request": request}
         ).data
@@ -214,10 +212,7 @@ class TeamList(generics.ListCreateAPIView):
                     ]
                 }
             )
-        #mut = data._mutable
-        #data._mutable = True
-        # data["players"] = [user.id]
-        #data._mutable = mut
+
         return super().post(request, *args, **kwargs)
 
 
@@ -280,11 +275,9 @@ class PlayerRegistrationList(generics.ListCreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        #mut = data._mutable
-        #data._mutable = True
         data["user"] = user.id
         data["payment"] = PaymentStatus.NOT_PAID
-        #data._mutable = mut
+
         return super().post(request, *args, **kwargs)
 
 
@@ -360,11 +353,9 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        #mut = data._mutable
-        #data._mutable = True
         data["user"] = user.id
         data["payment"] = PaymentStatus.NOT_PAID
-        #data._mutable = mut
+
         return super().post(request, *args, **kwargs)
 
 

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -181,7 +181,7 @@ class TournamentDetailsFull(APIView):
                 Player.objects.get(id=pid).pseudo for pid in team_preser["players"]
             ]
             team_preser["managers"] = [
-                Player.objects.get(id=pid).pseudo for pid in team_preser["managers"]
+                Manager.objects.get(id=pid).pseudo for pid in team_preser["managers"]
             ]
 
             teams_serialized.append(team_preser)
@@ -204,7 +204,7 @@ class TeamList(generics.ListCreateAPIView):
         user = request.user
         data = request.data
 
-        if user is None or not user.is_authenticated or "name" not in data:
+        if user is None or not user.is_authenticated or "name" not in data or "password" not in data:
             raise PermissionDenied()
 
         if not user.is_email_active():

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -273,7 +273,7 @@ class PlayerRegistrationList(generics.ListCreateAPIView):
                     ]
                 }
             )
-        
+
         if not check_password(data["password"], Team.objects.get(pk=data["team"]).get_password()):
             return Response(
                 { "password": _("Mot de passe invalide.")},
@@ -337,7 +337,7 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
             raise PermissionDenied()
 
         if (
-            "team" not in data 
+            "team" not in data
             or "payment" in data
             or "password" not in data
         ) :

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -150,8 +150,8 @@ class TournamentDetailsFull(APIView):
             return Response("", status=status.HTTP_400_BAD_REQUEST)
         tourney = tourneys[0]
         # if the tournament hasn't been yet announced, we don't want to return details of it
-        if not tourney.is_announced:
-            return Response({"id": primary_key}, status=status.HTTP_200_OK)
+        # if not tourney.is_announced:
+            # return Response({"id": primary_key}, status=status.HTTP_200_OK)
         tourney_serialized = serializers.TournamentSerializer(
             tourney, context={"request": request}
         ).data
@@ -200,7 +200,7 @@ class TeamList(generics.ListCreateAPIView):
     serializer_class = serializers.TeamSerializer
     permission_classes = [permissions.IsAuthenticated | ReadOnly]
 
-    def post(this, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         user = request.user
         data = request.data
 
@@ -332,7 +332,7 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
     serializer_class = serializers.ManagerSerializer
     queryset = Manager.objects.all().order_by("id")
 
-    def post(this, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         user = request.user
         data = request.data
 

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -158,6 +158,7 @@ class UserMailer:
             None,  # Django falls back to default of settings.py
             [user_object.email],
             fail_silently=False,
+            html_message="<h1>Je suis un test de HTML</h1>",
         )
 
     @staticmethod

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -148,17 +148,12 @@ class UserMailer:
         send_mail(
             _("Confirmez votre courriel"),
             _("Confirmez votre adresse de courriel en cliquant sur ")
-            + insalan.settings.PROTOCOL
-            + "://"
-            + insalan.settings.WEBSITE_HOST
-            + "/verification/"
-            + user
-            + "/"
-            + token,
+            + "http://api."
+            + getenv("WEBSITE_HOST", "localhost")
+            + reverse("confirm-email", kwargs={"user": user, "token": token}),
             None,  # Django falls back to default of settings.py
             [user_object.email],
             fail_silently=False,
-            html_message="<h1>Je suis un test de HTML</h1>",
         )
 
     @staticmethod


### PR DESCRIPTION
Add missing fields like team password (#88), player/manager pseudo and max number of teams in a tournament (#49). Also fixing unique registration per event validation.