### PR TITLE
Add patch team endpoint and tests

### DIFF
--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -443,6 +443,15 @@ class Team(models.Model):
         verbose_name=_("Mot de passe de l'équipe"),
     )
 
+    captain = models.ForeignKey(
+        "Player",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        verbose_name=_("Capitaine"),
+        related_name="team_captain",
+    )
+
     class Meta:
         """Meta Options"""
 
@@ -542,6 +551,12 @@ class Team(models.Model):
                 _("Tournoi complet")
             )
 
+    def save(self, *args, **kwargs):
+        if self.captain is None:
+            players = self.get_players()
+            if len(players) > 0:
+                self.captain = players[0]
+        super().save(*args, **kwargs)
 
 class PaymentStatus(models.TextChoices):
     """Information about the current payment status of a Player/Manager"""
@@ -635,6 +650,12 @@ class Player(models.Model):
 
     def save(self,*args,**kwargs):
         super().save(*args,**kwargs)
+        self.team.refresh_validation()
+
+    def delete(self,*args,**kwargs):
+        if self.team.captain == self:
+            self.team.captain = None
+        super().delete(*args,**kwargs)
         self.team.refresh_validation()
 
 

--- a/insalan/tournament/tests.py
+++ b/insalan/tournament/tests.py
@@ -991,6 +991,101 @@ class PlayerTestCase(TestCase):
 
         self.assertRaises(Player.DoesNotExist, Player.objects.get, id=play_obj.id)
 
+    def test_patch_user(self):
+        """
+        Test the patch method of the Player API
+        """
+        user = User.objects.get(username="testplayer")
+
+        player = Player.objects.get(user=user)
+
+        self.client.force_login(user=user)
+
+        # patch data
+        data = {
+            "name_in_game": "playerOneModified",
+        }
+
+        # patch request
+        request = self.client.patch(
+            f"/v1/tournament/player/{player.id}/",
+            data,
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 200)
+
+        # check data
+        self.assertEqual(request.data["name_in_game"], "playerOneModified")
+
+    def test_patch_user_not_owner(self):
+        """
+        Test the patch method of the Player API when the user is not related to the player
+        """
+        user = User.objects.get(username="testplayer")
+        user_two = User.objects.get(username="randomplayer")
+
+        player = Player.objects.get(user=user)
+
+        self.client.force_login(user=user_two)
+
+        # patch data
+        data = {
+            "name_in_game": "playerOneModified",
+        }
+
+        # patch request
+        request = self.client.patch(
+            f"/v1/tournament/player/{player.id}/",
+            data,
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 403)
+
+    def test_delete_user(self):
+        """
+        Test the delete method of the Player API
+        """
+        user = User.objects.get(username="testplayer")
+
+        player = Player.objects.get(user=user)
+
+        self.client.force_login(user=user)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/player/{player.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 204)
+
+        # check data
+        self.assertRaises(Player.DoesNotExist, Player.objects.get, id=player.id)
+
+    def test_delete_user_not_owner(self):
+        """
+        Test the delete method of the Player API when the user is not related to the player
+        """
+        user = User.objects.get(username="testplayer")
+        user_two = User.objects.get(username="randomplayer")
+
+        player = Player.objects.get(user=user)
+
+        self.client.force_login(user=user_two)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/player/{player.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 403)
 
 # TODO: Add tests of the API
 
@@ -1655,6 +1750,47 @@ class ManagerTestCase(TestCase):
 
         self.assertEqual(PaymentStatus.PAY_LATER, man_reg.payment_status)
 
+    def test_delete_manager(self):
+        """
+        Test the delete method of the Manager API
+        """
+        user = User.objects.get(username="randomplayer")
+
+        manager = Manager.objects.get(user=user)
+
+        self.client.force_login(user=user)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/manager/{manager.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 204)
+
+        # check data
+        self.assertRaises(Manager.DoesNotExist, Manager.objects.get, id=manager.id)
+
+    def test_delete_manager_not_owner(self):
+        """
+        Test the delete method of the Manager API when the user is not related to the manager
+        """
+        user = User.objects.get(username="randomplayer")
+        user_two = User.objects.get(username="testplayer")
+
+        manager = Manager.objects.get(user=user)
+
+        self.client.force_login(user=user_two)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/manager/{manager.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 403)
 
 # Substitute Class Tests
 class SubstituteTestCase(TestCase):
@@ -1936,6 +2072,101 @@ class SubstituteTestCase(TestCase):
 
         self.assertEqual(PaymentStatus.PAY_LATER, man_reg.payment_status)
 
+    def test_patch_substitute(self):
+        """
+        Test the patch method of the Substitute API
+        """
+        user = User.objects.get(username="randomplayer")
+
+        substitute = Substitute.objects.get(user=user)
+
+        self.client.force_login(user=user)
+
+        # patch data
+        data = {
+            "name_in_game": "new pseudo",
+        }
+
+        # patch request
+        request = self.client.patch(
+            f"/v1/tournament/substitute/{substitute.id}/",
+            data,
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 200)
+
+        # check data
+        self.assertEqual(request.data["name_in_game"], "new pseudo")
+
+    def test_patch_substitute_not_owner(self):
+        """
+        Test the patch method of the Substitute API when the user is not related to the substitute
+        """
+        user = User.objects.get(username="randomplayer")
+        user_two = User.objects.get(username="testplayer")
+
+        substitute = Substitute.objects.get(user=user)
+
+        self.client.force_login(user=user_two)
+
+        # patch data
+        data = {
+            "name_in_game": "new pseudo",
+        }
+
+        # patch request
+        request = self.client.patch(
+            f"/v1/tournament/substitute/{substitute.id}/",
+            data,
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 403)
+
+    def test_delete_substitute(self):
+        """
+        Test the delete method of the Substitute API
+        """
+        user = User.objects.get(username="randomplayer")
+
+        substitute = Substitute.objects.get(user=user)
+
+        self.client.force_login(user=user)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/substitute/{substitute.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 204)
+
+        # check data
+        self.assertRaises(Substitute.DoesNotExist, Substitute.objects.get, id=substitute.id)
+
+    def test_delete_substitute_not_owner(self):
+        """
+        Test the delete method of the Substitute API when the user is not related to the substitute
+        """
+        user = User.objects.get(username="randomplayer")
+        user_two = User.objects.get(username="testplayer")
+
+        substitute = Substitute.objects.get(user=user)
+
+        self.client.force_login(user=user_two)
+
+        # delete request
+        request = self.client.delete(
+            f"/v1/tournament/substitute/{substitute.id}/",
+            content_type="application/json",
+        )
+
+        # check response
+        self.assertEqual(request.status_code, 403)
 
 class TournamentTeamEndpoints(TestCase):
     """Tournament Registration Endpoint Test Class"""

--- a/insalan/tournament/tests.py
+++ b/insalan/tournament/tests.py
@@ -1049,10 +1049,11 @@ class TournamentFullDerefEndpoint(TestCase):
             is_announced=True,
         )
         team_one = Team.objects.create(name="Team One", tournament=tourneyobj_one)
-        Player.objects.create(user=uobj_one, team=team_one, name_in_game="playerone")
+        first = Player.objects.create(user=uobj_one, team=team_one, name_in_game="playerone")
         Player.objects.create(user=uobj_two, team=team_one, name_in_game="playertwo")
         Manager.objects.create(user=uobj_three, team=team_one)
         Substitute.objects.create(user=uobj_four, team=team_one, name_in_game="substitute")
+        team_one.save()
 
         request = self.client.get(
             reverse("tournament/details-full", args=[tourneyobj_one.id]), format="json"
@@ -1111,6 +1112,7 @@ class TournamentFullDerefEndpoint(TestCase):
                     "substitutes": [
                         {"user": "test_user_four", "name_in_game": "substitute", "payment_status": None},
                     ],
+                    "captain": first.id,
                     "validated": team_one.validated,
                 }
             ],

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -441,6 +441,62 @@ class PlayerRegistration(generics.RetrieveAPIView):
     serializer_class = serializers.PlayerSerializer
     queryset = Player.objects.all().order_by("id")
 
+    def patch(self, request, *args, **kwargs):
+        """
+        Patch a player
+        """
+        user = request.user
+        data = request.data
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the player
+        player = Player.objects.get(id=kwargs["pk"])
+
+        # check if the user is related to the player
+        if player.as_user().id != user.id:
+            return Response({
+                "player": _("Vous n'avez pas la permission de modifier cette inscription.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        if "name_in_game" in data:
+            player.name_in_game = data["name_in_game"]
+
+        player.save()
+
+        serializer = serializers.PlayerSerializer(player, context={"request": request})
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete a player
+        """
+        user = request.user
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the player
+        player = Player.objects.get(id=kwargs["pk"])
+
+        # check if the user is related to the player
+        if player.as_user().id != user.id:
+            return Response({
+                "player": _("Vous n'avez pas la permission de supprimer cette inscription.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        # if player has paid, can't delete
+        if player.payment_status != PaymentStatus.NOT_PAID:
+            return Response({
+                "player": _("Vous ne pouvez pas supprimer votre inscription si vous avez payé.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        player.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class PlayerRegistrationList(generics.ListCreateAPIView):
     """Get all player registrations"""
@@ -526,6 +582,34 @@ class ManagerRegistration(generics.RetrieveAPIView):
     serializer_class = serializers.ManagerSerializer
     queryset = Manager.objects.all().order_by("id")
 
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete a manager
+        """
+        user = request.user
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the manager
+        manager = Manager.objects.get(id=kwargs["pk"])
+
+        # check if the user is related to the manager
+        if manager.as_user().id != user.id:
+            return Response({
+                "manager": _("Vous n'avez pas la permission de supprimer cette inscription.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        # if manager has paid, can't delete
+        if manager.payment_status != PaymentStatus.NOT_PAID:
+            return Response({
+                "manager": _("Vous ne pouvez pas supprimer votre inscription si vous avez payé.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        manager.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class ManagerRegistrationList(generics.ListCreateAPIView):
     """Show all manager registrations"""
@@ -605,6 +689,62 @@ class SubstituteRegistration(generics.RetrieveAPIView):
 
     serializer_class = serializers.SubstituteSerializer
     queryset = Substitute.objects.all().order_by("id")
+
+    def patch(self, request, *args, **kwargs):
+        """
+        Patch a substitute
+        """
+        user = request.user
+        data = request.data
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the substitute
+        substitute = Substitute.objects.get(id=kwargs["pk"])
+
+        # check if the user is related to the substitute
+        if substitute.as_user().id != user.id:
+            return Response({
+                "substitute": _("Vous n'avez pas la permission de modifier cette inscription.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        if "name_in_game" in data:
+            substitute.name_in_game = data["name_in_game"]
+
+        substitute.save()
+
+        serializer = serializers.SubstituteIdSerializer(substitute, context={"request": request})
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete a substitute
+        """
+        user = request.user
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the substitute
+        substitute = Substitute.objects.get(id=kwargs["pk"])
+
+        # check if the user is related to the substitute
+        if substitute.as_user().id != user.id:
+            return Response({
+                "substitute": _("Vous n'avez pas la permission de supprimer cette inscription.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        # if substitute has paid, can't delete
+        if substitute.payment_status != PaymentStatus.NOT_PAID:
+            return Response({
+                "substitute": _("Vous ne pouvez pas supprimer votre inscription si vous avez payé.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        substitute.delete()
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 class SubstituteRegistrationList(generics.ListCreateAPIView):
     """Show all substitute registrations"""

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -714,7 +714,7 @@ class SubstituteRegistration(generics.RetrieveAPIView):
 
         substitute.save()
 
-        serializer = serializers.SubstituteIdSerializer(substitute, context={"request": request})
+        serializer = serializers.SubstituteSerializer(substitute, context={"request": request})
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -9,6 +9,7 @@ from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.hashers import check_password
 from django.http import QueryDict
+from django.contrib.auth.hashers import make_password
 
 from rest_framework import generics, permissions, status
 from rest_framework.exceptions import NotFound
@@ -17,10 +18,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
-from insalan.user.models import User
-from insalan.tournament import serializers
+from insalan.user.models import User, UserMailer
+import insalan.tournament.serializers as serializers
 
-from .models import Player, Manager, Substitute, Event, Tournament, Game, Team
+from .models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
 
 class ReadOnly(BasePermission):
     """Read-Only permissions"""
@@ -28,6 +29,13 @@ class ReadOnly(BasePermission):
     def has_permission(self, request, _view):
         """Define the permissions for this class"""
         return request.method in SAFE_METHODS
+
+class ReadOnlyPlusPatch(BasePermission):
+    """Admin or read-only permissions, plus patch"""
+
+    def has_permission(self, request, _view):
+        """Define the permissions for this class"""
+        return request.method in SAFE_METHODS or request.method == "PATCH"
 
 
 class EventList(generics.ListCreateAPIView):
@@ -342,8 +350,89 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
 
     queryset = Team.objects.all().order_by("id")
     serializer_class = serializers.TeamSerializer
-    permission_classes = [permissions.IsAdminUser | ReadOnly]
+    permission_classes = [permissions.IsAdminUser | ReadOnlyPlusPatch]
 
+    def patch(self, request, *args, **kwargs):
+        """
+        Patch a team
+        """
+        user = request.user
+        data = request.data
+
+        if user is None or not user.is_authenticated:
+            raise PermissionDenied()
+
+        # get the team
+        team = Team.objects.get(id=kwargs["pk"])
+
+        # check if the user is registered in the team
+        player = Player.objects.filter(user=user, team=team)
+        manager = Manager.objects.filter(user=user, team=team)
+        if len(player) == 0 and len(manager) == 0:
+            return Response({
+                "team": _("Vous n'êtes pas inscrit dans cette équipe.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        # check if the player is the team's captain or a manager
+        if len(manager) == 0 and team.get_players_id()[0] != player[0].id:
+            return Response({
+                "team": _("Vous n'avez pas la permission de modifier cette équipe.")
+            }, status=status.HTTP_403_FORBIDDEN)
+
+        # team name edit
+        if "name" in data and len(data["name"]) >= 3:
+            team.name = data["name"]
+
+        # team password edit
+        if "password" in data:
+            if len(data["password"]) >= 8:
+                team.password = make_password(data["password"])
+            else:
+                return Response({
+                    "password": _("Mot de passe invalide.")
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        # player edit
+        if "players" in data:
+            existing = set(team.get_players_id())
+            players = set(data["players"])
+            removed = existing - players
+            for uid in removed:
+                player = Player.objects.get(id=uid)
+                # if player hasn't paid, remove him from the team
+                if player.as_user().id != user.id and player.payment_status == PaymentStatus.NOT_PAID:
+                    UserMailer.send_kick_mail(player.as_user(), team.name, user.username)
+                    player.delete()
+
+        # manager edit
+        if "managers" in data:
+            existing = set(team.get_managers_id())
+            managers = set(data["managers"])
+            removed = existing - managers
+            for uid in removed:
+                manager = Manager.objects.get(id=uid)
+                # if manager hasn't paid, remove him from the team
+                if manager.as_user().id != user.id and manager.payment_status == PaymentStatus.NOT_PAID:
+                    UserMailer.send_kick_mail(manager.as_user(), team.name, user.username)
+                    manager.delete()
+
+        # substitute edit
+        if "substitutes" in data:
+            existing = set(team.get_substitutes_id())
+            substitutes = set(data["substitutes"])
+            removed = existing - substitutes
+            for uid in removed:
+                substitute = Substitute.objects.get(id=uid)
+                # if substitute hasn't paid, remove him from the team
+                if substitute.as_user().id != user.id and substitute.payment_status == PaymentStatus.NOT_PAID:
+                    UserMailer.send_kick_mail(substitute.as_user(), team.name, user.username)
+                    substitute.delete()
+
+        team.save()
+
+        serializer = serializers.TeamSerializer(team, context={"request": request})
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 # Registration finders
 class PlayerRegistration(generics.RetrieveAPIView):

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -495,6 +495,12 @@ class PlayerRegistration(generics.RetrieveAPIView):
 
         player.delete()
 
+        # if the team is empty, delete it
+        if len(player.team.get_players_id()) == 0 \
+            and len(player.team.get_managers_id()) == 0 \
+            and len(player.team.get_substitutes_id()) == 0:
+            player.team.delete()
+
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -607,6 +613,12 @@ class ManagerRegistration(generics.RetrieveAPIView):
             }, status=status.HTTP_403_FORBIDDEN)
 
         manager.delete()
+
+        # if the team is empty, delete it
+        if len(manager.team.get_players_id()) == 0 \
+            and len(manager.team.get_managers_id()) == 0 \
+            and len(manager.team.get_substitutes_id()) == 0:
+            manager.team.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -743,6 +755,12 @@ class SubstituteRegistration(generics.RetrieveAPIView):
             }, status=status.HTTP_403_FORBIDDEN)
 
         substitute.delete()
+
+        # if the team is empty, delete it
+        if len(substitute.team.get_players_id()) == 0 \
+            and len(substitute.team.get_managers_id()) == 0 \
+            and len(substitute.team.get_substitutes_id()) == 0:
+            substitute.team.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -30,12 +30,12 @@ class ReadOnly(BasePermission):
         """Define the permissions for this class"""
         return request.method in SAFE_METHODS
 
-class ReadOnlyPlusPatch(BasePermission):
-    """Admin or read-only permissions, plus patch"""
+class Patch(BasePermission):
+    """Is the request using HTTP Method PATCH"""
 
     def has_permission(self, request, _view):
         """Define the permissions for this class"""
-        return request.method in SAFE_METHODS or request.method == "PATCH"
+        return request.method == "PATCH"
 
 
 class EventList(generics.ListCreateAPIView):
@@ -350,7 +350,7 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
 
     queryset = Team.objects.all().order_by("id")
     serializer_class = serializers.TeamSerializer
-    permission_classes = [permissions.IsAdminUser | ReadOnlyPlusPatch]
+    permission_classes = [permissions.IsAdminUser | ReadOnly | Patch]
 
     def patch(self, request, *args, **kwargs):
         """
@@ -374,7 +374,7 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
             }, status=status.HTTP_403_FORBIDDEN)
 
         # check if the player is the team's captain or a manager
-        if len(manager) == 0 and team.get_players_id()[0] != player[0].id:
+        if len(manager) == 0 and team.captain.id != player[0].id:
             return Response({
                 "team": _("Vous n'avez pas la permission de modifier cette équipe.")
             }, status=status.HTTP_403_FORBIDDEN)

--- a/insalan/tournament/views.py
+++ b/insalan/tournament/views.py
@@ -401,7 +401,7 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
                 player = Player.objects.get(id=uid)
                 # if player hasn't paid, remove him from the team
                 if player.as_user().id != user.id and player.payment_status == PaymentStatus.NOT_PAID:
-                    UserMailer.send_kick_mail(player.as_user(), team.name, user.username)
+                    UserMailer.send_kick_mail(player.as_user(), team.name)
                     player.delete()
 
         # manager edit
@@ -413,7 +413,7 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
                 manager = Manager.objects.get(id=uid)
                 # if manager hasn't paid, remove him from the team
                 if manager.as_user().id != user.id and manager.payment_status == PaymentStatus.NOT_PAID:
-                    UserMailer.send_kick_mail(manager.as_user(), team.name, user.username)
+                    UserMailer.send_kick_mail(manager.as_user(), team.name)
                     manager.delete()
 
         # substitute edit
@@ -425,7 +425,7 @@ class TeamDetails(generics.RetrieveUpdateDestroyAPIView):
                 substitute = Substitute.objects.get(id=uid)
                 # if substitute hasn't paid, remove him from the team
                 if substitute.as_user().id != user.id and substitute.payment_status == PaymentStatus.NOT_PAID:
-                    UserMailer.send_kick_mail(substitute.as_user(), team.name, user.username)
+                    UserMailer.send_kick_mail(substitute.as_user(), team.name)
                     substitute.delete()
 
         team.save()

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -196,5 +196,18 @@ class UserMailer:
             fail_silently=False,
         )
 
+    @staticmethod
+    def send_kick_mail(user_object: User, team_name: str, user_name: str):
+        """
+        Send a mail to a user that has been kicked.
+        """
+        send_mail(
+            _("Vous avez été exclu.e de votre équipe"),
+            _("Vous avez été exclu.e de l'équipe ") + team_name
+            + _(" par ") + user_name + _("."),
+            None,  # Django falls back to default of settings.py
+            [user_object.email],
+            fail_silently=False,
+        )
 
 # vim: set tw=80 cc=80:

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -197,14 +197,13 @@ class UserMailer:
         )
 
     @staticmethod
-    def send_kick_mail(user_object: User, team_name: str, user_name: str):
+    def send_kick_mail(user_object: User, team_name: str):
         """
         Send a mail to a user that has been kicked.
         """
         send_mail(
             _("Vous avez été exclu.e de votre équipe"),
-            _("Vous avez été exclu.e de l'équipe ") + team_name
-            + _(" par ") + user_name + _("."),
+            _("Vous avez été exclu.e de l'équipe %s.") % team_name,
             None,  # Django falls back to default of settings.py
             [user_object.email],
             fail_silently=False,


### PR DESCRIPTION
Fix #103
Add team captain. When saving the team, chose the first player if there's not captain. 
Allow users to patch Team and tournaments :
- Team Patch :
  - raise 403 if user is not the captain or a manager
  - allow player kick if payment status is UNPAID
- Registration Patch :
  - allow name_in_game change only if login user is related to this registration
- Registration Delete :
  - allow registration deletion if user is related to this registration and hasn't paid.

Also add test to these endpoints.