### PR TITLE
Fix 500 on tournament product creation

### DIFF
--- a/insalan/payment/models.py
+++ b/insalan/payment/models.py
@@ -46,8 +46,8 @@ class Product(models.Model):
     price = models.DecimalField(
         null=False, max_digits=5, decimal_places=2, verbose_name=_("prix")
     )
-    name = models.CharField(max_length=50, verbose_name=_("intitulé"))
-    desc = models.CharField(max_length=50, verbose_name=_("description"))
+    name = models.CharField(max_length=80, verbose_name=_("intitulé"))
+    desc = models.CharField(max_length=80, verbose_name=_("description"))
     category = models.CharField(
         max_length=20,
         blank=False,


### PR DESCRIPTION
Fix a 500 when creating product associated with tournaments when name is too long. Product description was 50 char max "Inscription au tournoi {tournament.name} joueur" with tournament.name between 1 and 40 so it was causing a crash when > 20 chars.

This bug was found on v1.0.0 but not an emergency as it's only occurring during tournament creation.