### PR TITLE
Fix unable to edit team on full tournament

### DIFF
--- a/insalan/tournament/models.py
+++ b/insalan/tournament/models.py
@@ -903,6 +903,8 @@ def tournament_announced(tournament: Tournament):
 
 def tournament_registration_full(tournament: Tournament, exclude=None):
     """Validate if a tournament is full"""
+    if exclude is not None:
+        return False
     if tournament.get_validated_teams(exclude) >= tournament.get_max_team():
         return True
     return False


### PR DESCRIPTION
Fix a bug where you were unable to edit team when a tournament was full