### PR TITLE
Fix match ordering

### DIFF
--- a/insalan/tournament/models/bracket.py
+++ b/insalan/tournament/models/bracket.py
@@ -61,7 +61,7 @@ class Bracket(models.Model):
         return self.get_teams().values_list("id", flat=True)
 
     def get_matchs(self) -> List["KnockoutMatch"]:
-        return KnockoutMatch.objects.filter(bracket=self).order_by("id")
+        return KnockoutMatch.objects.filter(bracket=self)
 
     def get_winner(self) -> int:
         if self.bracket_type == BracketType.SINGLE:

--- a/insalan/tournament/models/group.py
+++ b/insalan/tournament/models/group.py
@@ -79,7 +79,7 @@ class Group(models.Model):
         return {team.id : score for team, score in leaderboard.items()}
 
     def get_matchs(self) -> List["GroupMatch"]:
-        return GroupMatch.objects.filter(group=self).order_by("id")
+        return GroupMatch.objects.filter(group=self)
 
 
 class Seeding(models.Model):

--- a/insalan/tournament/models/match.py
+++ b/insalan/tournament/models/match.py
@@ -53,6 +53,10 @@ class Match(models.Model):
         default=list,
         blank=True
     )
+
+    class Meta:
+
+        ordering = ["round_number","index_in_round"]
     
     def get_team_count(self) -> int:
         return len(self.get_teams())


### PR DESCRIPTION
Order for matches need to be by round and then index for a better view, specially in the `tournament/<id>/full`.