### PR TITLE
Add Swagger doc

### DIFF
--- a/insalan/cms/urls.py
+++ b/insalan/cms/urls.py
@@ -17,6 +17,6 @@ urlpatterns = [
     path("constant/<str:name>", views.ConstantFetch.as_view(), name="constant/name"),
     path("content/", views.ContentList.as_view(), name="content/list"),
     path(
-        "content/<str:section>/", views.ContentFetch.as_view(), name="content/section"
+        "content/<str:name>/", views.ContentFetch.as_view(), name="content/section"
     ),
 ]

--- a/insalan/langate/views.py
+++ b/insalan/langate/views.py
@@ -13,6 +13,9 @@ from rest_framework.generics import CreateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.tournament.models import Event, Player, PaymentStatus, Manager, Substitute
 from insalan.user.models import User
 

--- a/insalan/langate/views.py
+++ b/insalan/langate/views.py
@@ -31,6 +31,51 @@ class LangateUserView(CreateAPIView):
     authentication_classes = [SessionAuthentication]
     serializer_class = ReplySerializer
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "username": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom d'utilisateur")
+                ),
+                "password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Mot de passe")
+                ),
+            },
+        ),
+        responses={
+            200: serializer_class,
+            500: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Pas d'évènement en cours")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Nom d'utilisateur ou mot de passe incorrect")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Utilisateur non inscrit")
+                    )
+                }
+            ),
+        }
+    )
     def post(self, request, *args, **kwargs):
         """
         Function to handle retrieving and checking user data

--- a/insalan/partner/views.py
+++ b/insalan/partner/views.py
@@ -3,6 +3,9 @@ from rest_framework import generics, permissions
 from .models import Partner
 from .serializers import PartnerSerializer
 
+from django.utils.translation import gettext_lazy as _
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 
 class ReadOnly(permissions.BasePermission):
     def has_permission(self, request, view) -> bool:
@@ -15,8 +18,145 @@ class PartnerList(generics.ListCreateAPIView):
     serializer_class = PartnerSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
+    @swagger_auto_schema(
+        responses={
+            200: PartnerSerializer,
+            201: PartnerSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """
+        Create a partner
+        """
+        return super().post(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            200: PartnerSerializer,
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get all partners
+        """
+        return super().get(request, *args, **kwargs)
 
 class PartnerDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Partner.objects.all()
     serializer_class = PartnerSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
+
+    @swagger_auto_schema(
+        responses={
+            200: PartnerSerializer,
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Partenaire non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get a partner
+        """
+        return super().get(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            200: PartnerSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Partenaire non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def put(self, request, *args, **kwargs):
+        """
+        Update a partner
+        """
+        return super().put(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        responses={
+            200: PartnerSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Partenaire non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def patch(self, request, *args, **kwargs):
+        """
+        Partially update a partner
+        """
+        return super().patch(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Partenaire supprimé")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Partenaire non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete a partner
+        """
+        return super().delete(request, *args, **kwargs)

--- a/insalan/payment/views.py
+++ b/insalan/payment/views.py
@@ -16,6 +16,9 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 import insalan.settings as app_settings
 import insalan.payment.serializers as serializers
 
@@ -34,6 +37,17 @@ class ProductList(generics.ListAPIView):
     queryset = Product.objects.all()
     permission_classes = [permissions.IsAdminUser]
 
+    @swagger_auto_schema(
+        responses={
+            200: serializers.ProductSerializer,
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get all products
+        """
+        return super().get(request, *args, **kwargs)
+    
 
 class ProductDetails(generics.RetrieveUpdateDestroyAPIView):
     """
@@ -44,6 +58,96 @@ class ProductDetails(generics.RetrieveUpdateDestroyAPIView):
     queryset = Product.objects.all()
     permission_classes = [permissions.IsAdminUser]
 
+    @swagger_auto_schema(
+        responses={
+            200: serializers.ProductSerializer,
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get a product
+        """
+        return super().get(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        request_body=serializers.ProductSerializer,
+        responses={
+            200: serializers.ProductSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Produit non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def put(self, request, *args, **kwargs):
+        """
+        Update a product
+        """
+        return super().put(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        responses={
+            200: serializers.ProductSerializer,
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Produit non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """
+        Delete a product
+        """
+        return super().delete(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        request_body=serializers.ProductSerializer,
+        responses={
+            200: serializers.ProductSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Produit non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def patch(self, request, *args, **kwargs):
+        """
+        Partially update a product
+        """
+        return super().patch(request, *args, **kwargs)
 
 class TransactionList(generics.ListAPIView):
     """
@@ -73,12 +177,76 @@ class CreateProduct(generics.CreateAPIView):
     queryset = Product.objects.all()
     permission_classes = [permissions.IsAdminUser]
 
+    @swagger_auto_schema(
+        request_body=serializers.ProductSerializer,
+        responses={
+            200: serializers.ProductSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """
+        Create a product
+        """
+        return super().post(request, *args, **kwargs)
 
 class Notifications(APIView):
     """
     Notifications view
     """
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "metadata": openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "uuid": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("UUID of the transaction")
+                        )
+                    }
+                ),
+                "eventType": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Type of event")
+                ),
+                "data": openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    description=_("Data of the event")
+                )
+            }
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "success": openapi.Schema(
+                        type=openapi.TYPE_BOOLEAN,
+                        description=_("Notification received")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            )
+        }
+    )
     def post(self, request):
         """Notification POST"""
 
@@ -310,3 +478,54 @@ class PayView(generics.CreateAPIView):
             {"err": _("Données de transaction invalides")},
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "amount": openapi.Schema(
+                    type=openapi.TYPE_NUMBER,
+                    description=_("Montant à payer")
+                ),
+                "product": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("ID du produit")
+                ),
+                "payer": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("ID de l'utilisateur")
+                ),
+                "metadata": openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    description=_("Métadonnées")
+                )
+            }
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "success": openapi.Schema(
+                        type=openapi.TYPE_BOOLEAN,
+                        description=_("Paiement effectué")
+                    ),
+                    "redirect_url": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("URL de redirection")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données de transaction invalides")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """Process a payment request"""
+        return super().post(request, *args, **kwargs)

--- a/insalan/pizza/serializers.py
+++ b/insalan/pizza/serializers.py
@@ -68,6 +68,13 @@ class CreateOrderSerializer(serializers.ModelSerializer):
 
 class OrderIdSerializer(serializers.ModelSerializer):
     """ Serializer for an order"""
+
+    class Meta:
+        """
+        Serializer for an order
+        """
+        model = Order
+        fields = ("id", )
     
     def to_representation(self, instance):
         """Turn a Django object into a serialized representation"""
@@ -83,6 +90,14 @@ class TimeSlotSerializer(serializers.ModelSerializer):
 
 class TimeSlotIdSerializer(serializers.ModelSerializer):
     """Serializer for a timeslot model"""
+
+    class Meta:
+        """
+        Serializer for a timeslot model
+        """
+        model = TimeSlot
+        fields = ("id", )
+
     def to_representation(self, instance):
         """Turn a Django object into a serialized representation"""
         return instance.id

--- a/insalan/pizza/views.py
+++ b/insalan/pizza/views.py
@@ -69,6 +69,8 @@ class PizzaListByGivenTimeSlot(generics.RetrieveAPIView):
     """Group pizzas by timeslot"""
     pagination_class = None
     permission_classes = [ReadOnly]
+    serializer_class = serializers.PizzaByTimeSlotSerializer
+    queryset = TimeSlot.objects.all()
 
     def get(self, request, *args, **kwargs):
         if not TimeSlot.objects.filter(id=self.kwargs["pk"]).exists():
@@ -102,6 +104,7 @@ class TimeSlotDetail(generics.RetrieveAPIView, generics.DestroyAPIView):
     """Find a timeslot by its id"""
     queryset = TimeSlot.objects.all()
     permission_classes = [permissions.IsAdminUser]
+    serializer_class = serializers.TimeSlotSerializer
 
     def get(self, request, *args, **kwargs):
         if not TimeSlot.objects.filter(id=self.kwargs["pk"]).exists():
@@ -128,6 +131,7 @@ class NextTimeSlot(generics.ListAPIView):
     """Find the timeslot in the same day"""
     queryset = TimeSlot.objects.all()
     permission_classes = [ReadOnly]
+    serializer_class = serializers.TimeSlotSerializer
 
     def get(self, request, *args, **kwargs):
         # select incoming timeslot and currents timeslot in the same day

--- a/insalan/settings.py
+++ b/insalan/settings.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     "insalan.cms",
     "insalan.payment",
     "insalan.pizza",
+    "drf_yasg",
 ]
 
 MIDDLEWARE = [
@@ -101,6 +102,12 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+SWAGGER_SETTINGS = {
+    "USE_SESSION_AUTH": True,
+    "LOGIN_URL": "/v1/user/login/",
+    "LOGOUT_URL": "/v1/user/logout/",
+}
 
 ROOT_URLCONF = "insalan.urls"
 

--- a/insalan/tournament/models/group.py
+++ b/insalan/tournament/models/group.py
@@ -1,8 +1,7 @@
-from pyexpat import model
+from typing import List, Dict, Tuple
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from django.contrib.postgres.fields import ArrayField
-from typing import List, Dict, Tuple
 
 from . import team
 from . import match

--- a/insalan/tournament/models/match.py
+++ b/insalan/tournament/models/match.py
@@ -1,9 +1,10 @@
+from typing import List, Dict
+import math
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
-from typing import List, Dict
-import math
 from insalan.user.models import User
 
 class MatchStatus(models.TextChoices):

--- a/insalan/tournament/models/player.py
+++ b/insalan/tournament/models/player.py
@@ -9,7 +9,7 @@ from insalan.tickets.models import Ticket
 from insalan.user.models import User
 
 from .payement_status import PaymentStatus
-from . import team, validators, group, bracket, swiss, match
+from . import validators, group, bracket, swiss, match
 
 class Player(models.Model):
     """

--- a/insalan/tournament/models/swiss.py
+++ b/insalan/tournament/models/swiss.py
@@ -1,6 +1,7 @@
+from typing import List, Tuple
+
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from typing import List, Tuple
 from . import match
 
 class SwissRound(models.Model):

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from typing import List
 from django.db import models
 from django.core.validators import (
@@ -5,7 +7,6 @@ from django.core.validators import (
     MinValueValidator,
     MinLengthValidator,
 )
-from datetime import timedelta
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField

--- a/insalan/tournament/models/validators.py
+++ b/insalan/tournament/models/validators.py
@@ -1,8 +1,9 @@
-from insalan.user.models import User
+from collections import Counter
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework.validators import ValidationError
-from django.core.exceptions import BadRequest
-from collections import Counter
+
+from insalan.user.models import User
 
 # from .event import Event
 from . import player as play

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -306,6 +306,12 @@ class PlayerSerializer(serializers.ModelSerializer):
 class PlayerIdSerializer(serializers.Serializer):
     """Serializer to verify a list of player IDs"""
 
+    class Meta:
+        """Meta options for the serializer"""
+
+        model = Player
+        fields = "__all__"
+
     def to_representation(self, instance):
         """Turn a Django object into a serialized representation"""
         return instance.id
@@ -338,6 +344,12 @@ class ManagerSerializer(serializers.ModelSerializer):
 
 class ManagerIdSerializer(serializers.ModelSerializer):
     """Serializer to verify a list of manager IDs"""
+
+    class Meta:
+        """Meta options for the serializer"""
+
+        model = Manager
+        fields = "__all__"
 
     def to_representation(self, instance):
         """Turn a Django object into a serialized representation"""
@@ -373,6 +385,12 @@ class SubstituteSerializer(serializers.ModelSerializer):
 
 class SubstituteIdSerializer(serializers.ModelSerializer):
     """Serializer to verify a list of Substitute IDs"""
+
+    class Meta:
+        """Meta options for the serializer"""
+
+        model = Substitute
+        fields = "__all__"
 
     def to_representation(self, instance):
         """Turn a Django object into a serialized representation"""

--- a/insalan/tournament/views/bracket.py
+++ b/insalan/tournament/views/bracket.py
@@ -10,11 +10,9 @@ from drf_yasg import openapi
 
 import insalan.tournament.serializers as serializers
 
-from ..models import Bracket, KnockoutMatch, MatchStatus, BracketSet, validate_match_data
+from ..models import KnockoutMatch, validate_match_data
 # , InvalidScores, InvalidTeamList, InvalidTeamScore, NotOngoingMatch
 from ..manage import update_match_score, update_next_knockout_match
-
-from .permissions import ReadOnly, Patch
 
 class BracketMatchScore(generics.GenericAPIView):
     """Update score of a bracket match"""

--- a/insalan/tournament/views/event.py
+++ b/insalan/tournament/views/event.py
@@ -1,25 +1,16 @@
-from django.core.exceptions import PermissionDenied, BadRequest
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
-from django.contrib.auth.hashers import check_password
-from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
 from rest_framework import generics, permissions, status
-from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
-from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
-from .permissions import ReadOnly, Patch
+from ..models import Event, Tournament
+from .permissions import ReadOnly
 
 class EventList(generics.ListCreateAPIView):
     """List all of the existing events"""

--- a/insalan/tournament/views/event.py
+++ b/insalan/tournament/views/event.py
@@ -44,8 +44,9 @@ class EventDetails(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
 
-class EventDetailsSomeDeref(APIView):
+class EventDetailsSomeDeref(generics.RetrieveAPIView):
     """Details about an Event that dereferences tournaments, but nothing else"""
+    serializer_class = serializers.EventSerializer
 
     def get(self, request, primary_key: int):
         """GET handler"""

--- a/insalan/tournament/views/event.py
+++ b/insalan/tournament/views/event.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
@@ -26,6 +29,23 @@ class EventList(generics.ListCreateAPIView):
     serializer_class = serializers.EventSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
+    @swagger_auto_schema(
+        responses={
+            201: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """Create an event"""
+        return super().post(request, *args, **kwargs)
 
 class OngoingEventList(generics.ListAPIView):
     """List all of the ongoing events"""
@@ -42,14 +62,170 @@ class EventDetails(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = serializers.EventSerializer
     queryset = Event.objects.all().order_by("id")
     permission_classes = [permissions.IsAdminUser | ReadOnly]
+    
+    @swagger_auto_schema(
+        request_body=serializers.EventSerializer,
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Évènement introuvable")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier cet évènement")
+                    )
+                }
+            )
+        }
+    )
+    def put(self, request, *args, **kwargs):
+        """Update an event"""
+        return super().put(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Évènement supprimé")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Évènement introuvable")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à supprimer cet évènement")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """Delete an event"""
+        return super().delete(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Évènement introuvable")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier cet évènement")
+                    )
+                }
+            )
+        }
+    )
+    def patch(self, request, *args, **kwargs):
+        """Partially update an event"""
+        return super().patch(request, *args, **kwargs)
 
 
 class EventDetailsSomeDeref(generics.RetrieveAPIView):
     """Details about an Event that dereferences tournaments, but nothing else"""
-    serializer_class = serializers.EventSerializer
+    serializer_class = serializers.TournamentSerializer
 
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "id": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID du tournoi")
+                        ),
+                        "name": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Nom du tournoi")
+                        ),
+                        "is_announced": openapi.Schema(
+                            type=openapi.TYPE_BOOLEAN,
+                            description=_("Tournoi annoncé")
+                        ),
+                        "event": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID de l'évènement")
+                        )
+                    }
+                )
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Évènement introuvable")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à voir cet évènement")
+                    )
+                }
+            )
+        }
+    )
     def get(self, request, primary_key: int):
-        """GET handler"""
+        """
+        Get the tournaments of an event
+        """
         candidates = Event.objects.filter(id=primary_key)
         if len(candidates) == 0:
             raise Http404

--- a/insalan/tournament/views/game.py
+++ b/insalan/tournament/views/game.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
@@ -26,6 +29,33 @@ class GameList(generics.ListCreateAPIView):
     serializer_class = serializers.GameSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
+    @swagger_auto_schema(
+        responses={
+            201: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à créer un match")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """Create a game"""
+        return super().post(request, *args, **kwargs)
+
 
 class GameDetails(generics.RetrieveUpdateDestroyAPIView):
     """Details about a game"""
@@ -33,3 +63,129 @@ class GameDetails(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = serializers.GameSerializer
     queryset = Game.objects.all().order_by("id")
     permission_classes = [permissions.IsAdminUser | ReadOnly]
+
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier ce match")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Jeu non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def put(self, request, *args, **kwargs):
+        """Update a game"""
+        return super().put(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Jeu supprimé")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à supprimer ce jeu")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Jeu non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """Delete a game"""
+        return super().delete(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "team1_score": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("Score de l'équipe 1")
+                ),
+                "team2_score": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("Score de l'équipe 2")
+                ),
+            },
+        ),
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "team1_score": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Score de l'équipe 1")
+                    ),
+                    "team2_score": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Score de l'équipe 2")
+                    ),
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier ce match")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Match introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def patch(self, request, *args, **kwargs):
+        """
+        Partially update a game
+        """
+        return super().patch(request, *args, **kwargs)

--- a/insalan/tournament/views/game.py
+++ b/insalan/tournament/views/game.py
@@ -1,25 +1,14 @@
-from django.core.exceptions import PermissionDenied, BadRequest
-from django.http import Http404
 from django.utils.translation import gettext_lazy as _
-from django.contrib.auth.hashers import check_password
-from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
-from rest_framework import generics, permissions, status
-from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
+from rest_framework import generics, permissions
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
-from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
-from .permissions import ReadOnly, Patch
+from ..models import Game
+from .permissions import ReadOnly
 
 class GameList(generics.ListCreateAPIView):
     """List all known games"""

--- a/insalan/tournament/views/group.py
+++ b/insalan/tournament/views/group.py
@@ -10,17 +10,69 @@ import insalan.tournament.serializers as serializers
 from ..models import Group, GroupMatch, MatchStatus, validate_match_data
 from ..manage import update_match_score
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from .permissions import ReadOnly, Patch
 
 from collections import Counter
 
-class GroupMatchScore(generics.UpdateAPIView):
+class GroupMatchScore(generics.GenericAPIView):
     """Update score of a group match"""
 
     queryset = GroupMatch.objects.all().order_by("id")
     serializer_class = serializers.GroupMatchSerializer
     permission_classes = [permissions.IsAuthenticated]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "team1_score": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("Score de l'équipe 1")
+                ),
+                "team2_score": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("Score de l'équipe 2")
+                ),
+            },
+        ),
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "team1_score": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Score de l'équipe 1")
+                    ),
+                    "team2_score": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Score de l'équipe 2")
+                    ),
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier ce match")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Match introuvable")
+                    )
+                }
+            )
+        }
+    )
     def patch(self, request, *args, **kwargs):
         user = request.user
         data = request.data

--- a/insalan/tournament/views/group.py
+++ b/insalan/tournament/views/group.py
@@ -1,5 +1,5 @@
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import PermissionDenied, BadRequest
+from django.core.exceptions import PermissionDenied
 
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -7,15 +7,11 @@ from rest_framework.exceptions import NotFound
 
 import insalan.tournament.serializers as serializers
 
-from ..models import Group, GroupMatch, MatchStatus, validate_match_data
+from ..models import GroupMatch, validate_match_data
 from ..manage import update_match_score
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
-
-from .permissions import ReadOnly, Patch
-
-from collections import Counter
 
 class GroupMatchScore(generics.GenericAPIView):
     """Update score of a group match"""

--- a/insalan/tournament/views/manager.py
+++ b/insalan/tournament/views/manager.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
@@ -24,6 +27,29 @@ class ManagerRegistration(generics.RetrieveAPIView):
     serializer_class = serializers.ManagerSerializer
     queryset = Manager.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de voir cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
     def delete(self, request, *args, **kwargs):
         """
         Delete a manager
@@ -58,6 +84,25 @@ class ManagerRegistration(generics.RetrieveAPIView):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get a manager
+        """
+        return super().get(request, *args, **kwargs)
 
 class ManagerRegistrationList(generics.ListCreateAPIView):
     """Show all manager registrations"""
@@ -66,6 +111,34 @@ class ManagerRegistrationList(generics.ListCreateAPIView):
     serializer_class = serializers.ManagerSerializer
     queryset = Manager.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        request_body=serializers.ManagerSerializer,
+        responses={
+            201: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "team": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Équipe introuvable")
+                    ),
+                    "password": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Mot de passe invalide")
+                    ),
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à vous inscrire à ce tournoi")
+                    )
+                }
+            )
+        }
+    )
     def post(self, request, *args, **kwargs):
         user = request.user
         data = request.data
@@ -115,6 +188,40 @@ class ManagerRegistrationListId(generics.ListAPIView):
     def get_queryset(self):
         """Obtain the queryset fot this view"""
         return Manager.objects.filter(user_id=self.kwargs["user_id"])
+    
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "id": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID de l'inscription")
+                        ),
+                        "team": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID de l'équipe")
+                        ),
+                        "payment_status": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Statut de paiement")
+                        ),
+                        "ticket": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Ticket")
+                        )
+                    }
+                )
+            ),
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get all manager registrations of a user from their ID
+        """
+        return super().get(request, *args, **kwargs)
 
 
 class ManagerRegistrationListName(generics.ListAPIView):
@@ -131,3 +238,37 @@ class ManagerRegistrationListName(generics.ListAPIView):
         except User.DoesNotExist as exc:
             raise NotFound() from exc
         return Manager.objects.filter(user=user)
+    
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Schema(
+                    type=openapi.TYPE_OBJECT,
+                    properties={
+                        "id": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID de l'inscription")
+                        ),
+                        "team": openapi.Schema(
+                            type=openapi.TYPE_INTEGER,
+                            description=_("ID de l'équipe")
+                        ),
+                        "payment_status": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Statut de paiement")
+                        ),
+                        "ticket": openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Ticket")
+                        )
+                    }
+                )
+            ),
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get all manager registrations of a user from their username
+        """
+        return super().get(request, *args, **kwargs)

--- a/insalan/tournament/views/manager.py
+++ b/insalan/tournament/views/manager.py
@@ -1,16 +1,11 @@
 from django.core.exceptions import PermissionDenied, BadRequest
-from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.hashers import check_password
 from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
-from rest_framework import generics, permissions, status
+from rest_framework import generics, status
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -18,8 +13,7 @@ from drf_yasg import openapi
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
-from .permissions import ReadOnly, Patch
+from ..models import Manager, Team, PaymentStatus
 
 class ManagerRegistration(generics.RetrieveAPIView):
     """Show a manager registration"""

--- a/insalan/tournament/views/player.py
+++ b/insalan/tournament/views/player.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
@@ -25,6 +28,67 @@ class PlayerRegistration(generics.RetrieveAPIView):
     serializer_class = serializers.PlayerSerializer
     queryset = Player.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de voir cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get a player
+        """
+        return super().get(request, *args, **kwargs)
+
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de voir cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
     def patch(self, request, *args, **kwargs):
         """
         Patch a player
@@ -53,6 +117,28 @@ class PlayerRegistration(generics.RetrieveAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription supprimée")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de supprimer cette inscription")
+                    )
+                }
+            )
+        }
+    )
     def delete(self, request, *args, **kwargs):
         """
         Delete a player
@@ -95,6 +181,38 @@ class PlayerRegistrationList(generics.ListCreateAPIView):
     serializer_class = serializers.PlayerSerializer
     queryset = Player.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        request_body=serializers.PlayerSerializer,
+        responses={
+            201: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "team": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Équipe invalide")
+                    ),
+                    "password": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Mot de passe invalide")
+                    ),
+                    "name_in_game": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Nom en jeu invalide")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à vous inscrire à ce tournoi")
+                    )
+                }
+            )
+        }
+    )
     def post(self, request, *args, **kwargs):
         user = request.user
         data = request.data

--- a/insalan/tournament/views/player.py
+++ b/insalan/tournament/views/player.py
@@ -1,16 +1,11 @@
 from django.core.exceptions import PermissionDenied, BadRequest
-from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.hashers import check_password
 from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
-from rest_framework import generics, permissions, status
+from rest_framework import generics, status
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -18,8 +13,7 @@ from drf_yasg import openapi
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
-from .permissions import ReadOnly, Patch
+from ..models import Player, Team, PaymentStatus
 
 
 class PlayerRegistration(generics.RetrieveAPIView):

--- a/insalan/tournament/views/substitute.py
+++ b/insalan/tournament/views/substitute.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
@@ -25,6 +28,67 @@ class SubstituteRegistration(generics.RetrieveAPIView):
     serializer_class = serializers.SubstituteSerializer
     queryset = Substitute.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de voir cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """
+        Get a substitute
+        """
+        return super().get(request, *args, **kwargs)
+        
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de voir cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
     def patch(self, request, *args, **kwargs):
         """
         Patch a substitute
@@ -53,6 +117,29 @@ class SubstituteRegistration(generics.RetrieveAPIView):
 
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'avez pas la permission de supprimer cette inscription")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Inscription introuvable")
+                    )
+                }
+            )
+        }
+    )
     def delete(self, request, *args, **kwargs):
         """
         Delete a substitute
@@ -94,6 +181,54 @@ class SubstituteRegistrationList(generics.ListCreateAPIView):
     serializer_class = serializers.SubstituteSerializer
     queryset = Substitute.objects.all().order_by("id")
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "team": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description=_("ID de l'équipe")
+                ),
+                "password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Mot de passe de l'équipe")
+                ),
+                "name_in_game": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Pseudo en jeu")
+                ),
+            },
+        ),
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "team": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("ID de l'équipe")
+                    ),
+                    "password": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Mot de passe de l'équipe")
+                    ),
+                    "name_in_game": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Pseudo en jeu")
+                    ),
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à vous inscrire à un tournoi")
+                    )
+                }
+            )
+        }
+    )
     def post(self, request, *args, **kwargs):
         user = request.user
         data = request.data

--- a/insalan/tournament/views/substitute.py
+++ b/insalan/tournament/views/substitute.py
@@ -1,16 +1,11 @@
 from django.core.exceptions import PermissionDenied, BadRequest
-from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.hashers import check_password
 from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
-from rest_framework import generics, permissions, status
+from rest_framework import generics, status
 from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -18,9 +13,7 @@ from drf_yasg import openapi
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
-from .permissions import ReadOnly, Patch
-
+from ..models import Substitute, Team, PaymentStatus
 
 class SubstituteRegistration(generics.RetrieveAPIView):
     """Show a substitute registration"""

--- a/insalan/tournament/views/swiss.py
+++ b/insalan/tournament/views/swiss.py
@@ -1,5 +1,5 @@
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import PermissionDenied, BadRequest
+from django.core.exceptions import PermissionDenied
 
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
@@ -10,12 +10,8 @@ from drf_yasg import openapi
 
 import insalan.tournament.serializers as serializers
 
-from ..models import SwissRound, SwissMatch, MatchStatus, validate_match_data
-from ..manage import update_match_score, update_next_knockout_match
-
-from .permissions import ReadOnly, Patch
-
-from collections import Counter
+from ..models import SwissMatch, validate_match_data
+from ..manage import update_match_score
 
 class SwissMatchScore(generics.GenericAPIView):
     """Update score of a swiss match"""

--- a/insalan/tournament/views/team.py
+++ b/insalan/tournament/views/team.py
@@ -1,26 +1,18 @@
-from django.core.exceptions import PermissionDenied, BadRequest
-from django.http import Http404
+from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy as _
-from django.contrib.auth.hashers import check_password
-from django.http import QueryDict
 from django.contrib.auth.hashers import make_password
 
 from rest_framework import generics, permissions, status
-from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
 from insalan.settings import EMAIL_AUTH
 from insalan.mailer import MailManager
-from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus
+from ..models import Player, Manager, Substitute, Team, PaymentStatus
 from .permissions import ReadOnly, Patch
 
 

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -12,6 +12,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.tickets.models import Ticket
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
@@ -28,6 +31,33 @@ class TournamentList(generics.ListCreateAPIView):
     serializer_class = serializers.TournamentSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
+    @swagger_auto_schema(
+        responses={
+            201: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à créer un tournoi")
+                    )
+                }
+            )
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        """Create a tournament"""
+        return super().post(request, *args, **kwargs)
+
 
 class TournamentDetails(generics.RetrieveUpdateDestroyAPIView):
     """Details about a tournament"""
@@ -35,6 +65,131 @@ class TournamentDetails(generics.RetrieveUpdateDestroyAPIView):
     queryset = Tournament.objects.all().order_by("id")
     serializer_class = serializers.TournamentSerializer
     permission_classes = [permissions.IsAdminUser | ReadOnly]
+
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournoi introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        """Get a tournament"""
+        return super().get(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier un tournoi")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournoi introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def patch(self, request, *args, **kwargs):
+        """Patch a tournament"""
+        return super().patch(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournoi supprimé")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à supprimer un tournoi")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournoi introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """Delete a tournament"""
+        return super().delete(request, *args, **kwargs)
+    
+    @swagger_auto_schema(
+        responses={
+            200: serializer_class,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Données invalides")
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à modifier un tournoi")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournoi introuvable")
+                    )
+                }
+            )
+        }
+    )
+    def put(self, request, *args, **kwargs):
+        """Put a tournament"""
+        return super().put(request, *args, **kwargs)
 
 
 class TournamentDetailsFull(generics.RetrieveAPIView):
@@ -157,7 +312,7 @@ class TournamentDetailsFull(generics.RetrieveAPIView):
         return Response(tourney_serialized, status=status.HTTP_200_OK)
 
 
-class TournamentMe(generics.ListAPIView):
+class TournamentMe(generics.RetrieveAPIView):
     """
     Details on tournament of a logged user
     This endpoint does many requests to the database and should be used wisely
@@ -165,8 +320,139 @@ class TournamentMe(generics.ListAPIView):
     authentication_classes =  [SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated & ReadOnly]
     serializer_class = serializers.PlayerSerializer
+    pagination_class = None
 
-    def get(self, request):
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "player": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                "name_in_game": openapi.Schema(type=openapi.TYPE_STRING),
+                                "team": openapi.Schema(
+                                    type=openapi.TYPE_OBJECT,
+                                    properties={
+                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                        "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                        "tournament": openapi.Schema(
+                                            type=openapi.TYPE_OBJECT,
+                                            properties={
+                                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                                "event": openapi.Schema(
+                                                    type=openapi.TYPE_OBJECT,
+                                                    properties={
+                                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                        "name": openapi.Schema(type=openapi.TYPE_STRING)
+                                                    }
+                                                )
+                                            }
+                                        )
+                                    }
+                                ),
+                                "ticket": openapi.Schema(type=openapi.TYPE_STRING)
+                            }
+                        )
+                    ),
+                    "manager": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                "team": openapi.Schema(
+                                    type=openapi.TYPE_OBJECT,
+                                    properties={
+                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                        "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                        "tournament": openapi.Schema(
+                                            type=openapi.TYPE_OBJECT,
+                                            properties={
+                                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                                "event": openapi.Schema(
+                                                    type=openapi.TYPE_OBJECT,
+                                                    properties={
+                                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                        "name": openapi.Schema(type=openapi.TYPE_STRING)
+                                                    }
+                                                )
+                                            }
+                                        )
+                                    }
+                                ),
+                                "ticket": openapi.Schema(type=openapi.TYPE_STRING)
+                            }
+                        )
+                    ),
+                    "substitute": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_OBJECT,
+                            properties={
+                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                "name_in_game": openapi.Schema(type=openapi.TYPE_STRING),
+                                "team": openapi.Schema(
+                                    type=openapi.TYPE_OBJECT,
+                                    properties={
+                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                        "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                        "tournament": openapi.Schema(
+                                            type=openapi.TYPE_OBJECT,
+                                            properties={
+                                                "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                "name": openapi.Schema(type=openapi.TYPE_STRING),
+                                                "event": openapi.Schema(
+                                                    type=openapi.TYPE_OBJECT,
+                                                    properties={
+                                                        "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                                                        "name": openapi.Schema(type=openapi.TYPE_STRING)
+                                                    }
+                                                )
+                                            }
+                                        )
+                                    }
+                                ),
+                                "ticket": openapi.Schema(type=openapi.TYPE_STRING)
+                            }
+                        )
+                    ),
+                    "ongoing_match": openapi.Schema(
+                        type=openapi.TYPE_OBJECT,
+                        properties={
+                            "id": openapi.Schema(type=openapi.TYPE_INTEGER),
+                            "match_type": openapi.Schema(
+                                type=openapi.TYPE_OBJECT,
+                                properties={
+                                    "type": openapi.Schema(type=openapi.TYPE_STRING),
+                                    "id": openapi.Schema(type=openapi.TYPE_INTEGER)
+                                }
+                            ),
+                            "teams": openapi.Schema(
+                                type=openapi.TYPE_OBJECT,
+                                additional_properties=openapi.Schema(type=openapi.TYPE_STRING)
+                            )
+                        }
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à accéder à ces informations")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request, *args, **kwargs):
         """
         GET handler
         """

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -37,8 +37,9 @@ class TournamentDetails(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [permissions.IsAdminUser | ReadOnly]
 
 
-class TournamentDetailsFull(APIView):
+class TournamentDetailsFull(generics.RetrieveAPIView):
     """Details about a tournament, with full dereferencing of data"""
+    serializer_class = serializers.TournamentSerializer
 
     def get(self, request, primary_key: int):
         """Handle the GET word"""
@@ -156,13 +157,14 @@ class TournamentDetailsFull(APIView):
         return Response(tourney_serialized, status=status.HTTP_200_OK)
 
 
-class TournamentMe(APIView):
+class TournamentMe(generics.ListAPIView):
     """
     Details on tournament of a logged user
     This endpoint does many requests to the database and should be used wisely
     """
     authentication_classes =  [SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated & ReadOnly]
+    serializer_class = serializers.PlayerSerializer
 
     def get(self, request):
         """

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -1,15 +1,9 @@
-from django.core.exceptions import PermissionDenied, BadRequest
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
-from django.contrib.auth.hashers import check_password
-from django.http import QueryDict
-from django.contrib.auth.hashers import make_password
 
 from rest_framework import generics, permissions, status
-from rest_framework.exceptions import NotFound
-from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.views import APIView
 from rest_framework.authentication import SessionAuthentication
 
 from drf_yasg.utils import swagger_auto_schema
@@ -19,9 +13,8 @@ from insalan.tickets.models import Ticket
 from insalan.user.models import User
 import insalan.tournament.serializers as serializers
 
-from ..models import Player, Manager, Substitute, Event, Tournament, Game, Team, PaymentStatus, Group, Bracket, SwissRound, GroupMatch, KnockoutMatch, SwissMatch
-from .permissions import ReadOnly, Patch
-
+from ..models import Player, Manager, Substitute, Event, Tournament, Team, Group, Bracket, SwissRound, GroupMatch, KnockoutMatch, SwissMatch
+from .permissions import ReadOnly
 
 class TournamentList(generics.ListCreateAPIView):
     """List all known tournaments"""

--- a/insalan/urls.py
+++ b/insalan/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from os import getenv
 
+from django.urls import re_path
 from django.contrib import admin
 from django.views.generic.base import RedirectView
 from django.urls import include, path
 from rest_framework import routers
+from rest_framework import permissions
 
 from insalan.mailer import start_scheduler
 from insalan.langate import views as langate_views
@@ -37,6 +39,25 @@ urlpatterns = [
     path("v1/payment/", include("insalan.payment.urls")),
     path("v1/pizza/", include("insalan.pizza.urls")),
 ]
+if getenv("DEV", "1") == "1":
+    from drf_yasg.views import get_schema_view
+    from drf_yasg import openapi
+
+    schema_view = get_schema_view(
+        openapi.Info(
+            title="InsaLAN API",
+            default_version='v1',
+            description="Cette API est l'API privée de l'INSALAN. Elle est utilisée pour gérer les inscriptions, les tournois, les partenaires, les utilisateurs, les tickets et le contenu du site l'INSALAN.",
+        ),
+        public=True,
+        permission_classes=(permissions.AllowAny,),
+    )
+
+    urlpatterns += [
+        re_path(r'^v1/swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+        path("v1/swagger/", schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+        path("v1/redoc/", schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc-ui'),
+    ]
 
 if not int(getenv("DEV", "1")):
     urlpatterns.insert(1,

--- a/insalan/user/views.py
+++ b/insalan/user/views.py
@@ -52,7 +52,7 @@ class UserView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = UserSerializer
 
 
-class UserMe(APIView):
+class UserMe(generics.RetrieveAPIView):
     """
     API endpoint that allows a logged in user to get and set some of their own
     account fields.
@@ -60,6 +60,7 @@ class UserMe(APIView):
 
     authentication_classes = [SessionAuthentication]
     permission_classes = [permissions.IsAuthenticated]
+    serializer_class = UserSerializer
 
     def get(self, request):
         """

--- a/insalan/user/views.py
+++ b/insalan/user/views.py
@@ -20,6 +20,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.core.exceptions import ValidationError
 
+from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
+
 from insalan.user.serializers import (
     GroupSerializer,
     PermissionSerializer,
@@ -76,6 +79,83 @@ class UserMe(generics.RetrieveAPIView):
 
         return Response(user)
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "email": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Adresse de courriel")
+                ),
+                "first_name": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Prénom")
+                ),
+                "last_name": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom de famille")
+                ),
+                "display_name": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom d'affichage")
+                ),
+                "pronouns": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Pronoms")
+                ),
+                "status": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Statut")
+                ),
+                "new_password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nouveau mot de passe")
+                ),
+                "password_validation": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Validation du mot de passe")
+                ),
+                "current_password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Mot de passe actuel")
+                ),
+            },
+        ),
+        responses={
+            200: UserSerializer,
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "password": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Mot de passe invalide")
+                        )
+                    ),
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Données invalides")
+                        )
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "password": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Mot de passe actuel invalide")
+                        )
+                    )
+                }
+            )
+        }
+    )
     def patch(self, request):
         """
         Edit the current user following some limitations
@@ -177,6 +257,31 @@ class EmailConfirmView(APIView):
     permissions_classes = [permissions.AllowAny]
     authentication_classes = [SessionAuthentication]
 
+    @swagger_auto_schema(
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "msg": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Adresse de courriel confirmée")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Utilisateur·rice ou jeton invalide (ou adresse déjà confirmée)")
+                        )
+                    )
+                }
+            )
+        }
+    )
     def get(self, request, user=None, token=None):
         """
         If requested with valid parameters, will validate an user's email
@@ -212,6 +317,28 @@ class AskForPasswordReset(APIView):
     permissions_classes = [permissions.AllowAny]
     authentication_classes = [SessionAuthentication]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "email": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Adresse de courriel")
+                ),
+            },
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "msg": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Courriel de ré-initialisation envoyé")
+                    )
+                }
+            ),
+        }
+    )
     def post(self, request):
         """
         If requested with valid parameters, will send a password reset email to
@@ -234,6 +361,52 @@ class ResetPassword(APIView):
     permissions_classes = [permissions.AllowAny]
     authentication_classes = [SessionAuthentication]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "user": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom d'utilisateur")
+                ),
+                "token": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Jeton de ré-initialisation")
+                ),
+                "password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nouveau mot de passe")
+                ),
+                "password_confirm": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Confirmation du nouveau mot de passe")
+                ),
+            },
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "msg": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Mot de passe ré-initialisé")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Champ manquant/mot de passe invalide")
+                        )
+                    )
+                }
+            )
+        }
+    )
     def post(self, request):
         """
         If requested with valid parameters, will reset an user password
@@ -253,20 +426,22 @@ class ResetPassword(APIView):
             user_object: User = User.object.get(username=data["user"])
             if default_token_generator.check_token(user_object, data["token"]):
                 if data["password"] == data["password_confirm"]:
-                    validation_errors = validate_password(
-                        data["password"], user=user_object
-                    )
-                    if validation_errors is None:
-                        user_object.set_password(data["password"])
-                        user_object.save()
-                        return Response()
-                    return Response(
-                        {
-                            "user": [_("Mot de passe trop simple ou invalide")],
-                            "errors": validation_errors,
-                        },
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
+                    try:
+                        validate_password(
+                            data["password"], user=user_object
+                        )
+                    except ValidationError as err:
+                        validation_errors = err.messages
+                        return Response(
+                            {
+                                "user": [_("Mot de passe trop simple ou invalide")],
+                                "errors": validation_errors,
+                            },
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
+                    user_object.set_password(data["password"])
+                    user_object.save()
+                    return Response()
                 return Response(
                     {"user": [_("Les mots de passe diffèrent")]},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -282,9 +457,6 @@ class ResetPassword(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        return Response({}, status=status.HTTP_501_NOT_IMPLEMENTED)
-
-
 class ResendEmailConfirmView(APIView):
     """
     API endpoint to re-send a confirmation email
@@ -293,6 +465,40 @@ class ResendEmailConfirmView(APIView):
     permissions_classes = [permissions.AllowAny]
     authentication_classes = [SessionAuthentication]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "username": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom d'utilisateur")
+                ),
+            },
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "msg": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Courriel de confirmation renvoyé")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Impossible de renvoyer le courriel de confirmation")
+                        )
+                    )
+                }
+            )
+        }
+    )
     def post(self, request):
         """
         If the user is found, will send again a confirmation email
@@ -340,6 +546,68 @@ class UserLogin(APIView):
     permission_classes = [permissions.AllowAny]
     authentication_classes = [SessionAuthentication]
 
+    @swagger_auto_schema(
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                "username": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Nom d'utilisateur")
+                ),
+                "password": openapi.Schema(
+                    type=openapi.TYPE_STRING,
+                    description=_("Mot de passe")
+                ),
+            },
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Utilisateur·rice connecté·e")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Format des données soumises invalide")
+                        )
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Nom d'utilisateur·rice ou mot de passe incorrect")
+                        )
+                    )
+                }
+            ),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "user": openapi.Schema(
+                        type=openapi.TYPE_ARRAY,
+                        items=openapi.Schema(
+                            type=openapi.TYPE_STRING,
+                            description=_("Veuillez confirmer votre adresse de courriel")
+                        )
+                    )
+                }
+            )
+        }
+    )
     def post(self, request):
         """
         Submit a login form

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.31.0
 reportlab==4.0.9
 pillow==10.2.0 
 APScheduler==3.10.4
+drf-yasg==1.21.7


### PR DESCRIPTION
Add a swagger and a openapi yaml/json endpoint. The main reason to add this is to have a list of every endpoints easily readable for new members. These endpoints are only accessible on a dev environment.
This doc should always be maintains in the future.

Also prune the tournament imports and fix a few bugs (500 on reset password validation, `content/{id} not working,...`