### PR TITLE
Add tournament ordering

### DIFF
--- a/insalan/admin.py
+++ b/insalan/admin.py
@@ -1,0 +1,26 @@
+# Covering django.contrib.admin.AdminSite.get_app_list
+from django.contrib import admin
+
+ADMIN_ORDERING = []
+
+# Creating a sort function
+def get_app_list(self, request):
+    app_dict = self._build_app_dict(request)
+
+    ordering = []
+    # For each app in the app list
+    for app_name, app_data in app_dict.items():
+        # If app_name is not in ADMIN_ORDERING
+        if app_name not in [x[0] for x in ADMIN_ORDERING]:
+            # Add basic ordering
+            ordering.append((app_name, [x['object_name'] for x in app_data['models']]))
+    ordering += ADMIN_ORDERING
+
+    # For each app in the Ordering list
+    for app_name, object_list in ordering:
+        app = app_dict[app_name]
+        # Sort the models
+        app['models'].sort(key=lambda x: object_list.index(x['object_name']))
+        yield app
+
+admin.AdminSite.get_app_list = get_app_list

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -32,6 +32,29 @@ from insalan.tournament.manage import create_group_matchs, create_empty_knockout
 
 sensitive_post_parameters_m = method_decorator(sensitive_post_parameters())
 
+from insalan.admin import ADMIN_ORDERING
+ADMIN_ORDERING += [
+    ('tournament', [
+        'Event',
+        'Game',
+        'Tournament',
+        'Team',
+        'Player',
+        'Manager',
+        'Substitute',
+        'Caster',
+        'TournamentMailer',
+        'Group',
+        'GroupMatch',
+        'Bracket',
+        'BracketMatch',
+        'Knockout',
+        'KnockoutMatch',
+        'SwissRound',
+        'SwissMatch',
+    ]),
+]
+
 class EventAdmin(admin.ModelAdmin):
     """Admin handler for Events"""
 


### PR DESCRIPTION
## Description

Add admin panel ordering for tournament.
As django doesn't allow native admin panel ordering, I had to come up with some strange codes.

The others apps are not ordered but with this code, you can sort further apps if needed.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [N/A] I have added tests to cover my changes.
- [N/A] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.


## Screenshots

Old :
![image](https://github.com/InsaLan/backend-insalan.fr/assets/35538496/b82aa01a-9624-4d14-bec2-a91f0cb9c1e4)
New :
![image](https://github.com/InsaLan/backend-insalan.fr/assets/35538496/195e3ce1-6b43-428a-93d8-6c7e45a983be)


