### PR TITLE
Add team sorting in group

### DIFF
--- a/insalan/admin.py
+++ b/insalan/admin.py
@@ -4,8 +4,8 @@ from django.contrib import admin
 ADMIN_ORDERING = []
 
 # Creating a sort function
-def get_app_list(self, request):
-    app_dict = self._build_app_dict(request)
+def get_app_list(self, request, app_label=None):
+    app_dict = self._build_app_dict(request, app_label)
 
     ordering = []
     # For each app in the app list
@@ -16,11 +16,16 @@ def get_app_list(self, request):
             ordering.append((app_name, [x['object_name'] for x in app_data['models']]))
     ordering += ADMIN_ORDERING
 
+    app_list = []
     # For each app in the Ordering list
     for app_name, object_list in ordering:
+        if app_name not in app_dict:
+            continue
         app = app_dict[app_name]
         # Sort the models
         app['models'].sort(key=lambda x: object_list.index(x['object_name']))
-        yield app
+        app_list.append(app)
+
+    return app_list
 
 admin.AdminSite.get_app_list = get_app_list

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -296,6 +296,9 @@ class TournamentDetailsFull(generics.RetrieveAPIView):
 
                 group["scores"] = {team: sum(match["score"][team] for match in group["matchs"] if team in match["score"]) for team in group["teams"]}
 
+                # order teams by score
+                group["teams"] = sorted(group["teams"], key=lambda x: group["scores"][x], reverse=True)
+
             # deref bracket matchs and scores
             tourney_serialized["brackets"] = serializers.FullDerefBracketSerializer(
                 Bracket.objects.filter(tournament=tourney), context={"request": request}, many=True
@@ -315,7 +318,7 @@ class TournamentDetailsFull(generics.RetrieveAPIView):
 
                 bracket["depth"] = math.ceil(math.log2(bracket["team_count"]/tourney_serialized["game"]["team_per_match"])) + 1
 
-                bracket["teams"] = set(matches.values_list("teams", flat=True))
+                bracket["teams"] = set(matches.values_list("teams", flat=True).filter(teams__isnull=False))
 
                 bracket["winner"] = None
 


### PR DESCRIPTION
## Description

In Tournament/full : groups.teams, change the order from random to sorted by score.
Also remove null in teams list for brackets.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [N/A] I have added tests to cover my changes.
- [N/A] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.
