### PR TITLE
Fix 500 error when new team name is already used

### DIFF
--- a/insalan/tournament/views/team.py
+++ b/insalan/tournament/views/team.py
@@ -60,6 +60,11 @@ class TeamList(generics.ListCreateAPIView):
                 }
             )
 
+        if self.queryset.filter(name__exact=request.data["name"]).exists():
+            return Response({
+                "name": _("Ce nom d'équipe est déjà pris.")
+            }, status=status.HTTP_400_BAD_REQUEST)
+
         return super().post(request, *args, **kwargs)
 
 


### PR DESCRIPTION
## Description

API returns proper 400 HTTP response instead of 500, such that it appears as an error message.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [N/A?] I have added tests to cover my changes.
- [N/A] I have updated the documentation accordingly.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.


## Related Issues

- Fixes #104 

## Screenshots

![image](https://github.com/InsaLan/backend-insalan.fr/assets/38759407/60997f54-b815-44b9-9776-c18367a5337d)
