### PR TITLE
Add a new field that convert images to webp

### DIFF
--- a/insalan/components/image_field.py
+++ b/insalan/components/image_field.py
@@ -1,0 +1,33 @@
+import os
+from io import BytesIO
+
+from django.core.exceptions import ValidationError
+from django.db import models
+from PIL import Image
+
+class ImageField(models.ImageField):
+    """
+        A subclass of Django's ImageField that convert the image to a webp format
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.convert_to_webp = kwargs.pop("convert_to_webp", True)
+        super().__init__(*args, **kwargs)
+
+    def pre_save(self, model_instance, add):
+        file = super().pre_save(model_instance, add)
+        if self.convert_to_webp:
+            try:
+                img = Image.open(file)
+                if img.format != "WEBP":
+                    buffer = BytesIO()
+                    img.save(buffer, format="WEBP")
+                    buffer.seek(0)
+                    file.save(
+                        os.path.basename(os.path.splitext(file.name)[0]) + ".webp",
+                        buffer,
+                        save=False,
+                    )
+            except Exception as e:
+                raise ValidationError(f"Invalid image file: {e}") from e
+        return file

--- a/insalan/components/image_field.py
+++ b/insalan/components/image_field.py
@@ -16,6 +16,8 @@ class ImageField(models.ImageField):
 
     def pre_save(self, model_instance, add):
         file = super().pre_save(model_instance, add)
+        if not file:
+            return file
         if self.convert_to_webp:
             try:
                 img = Image.open(file)

--- a/insalan/components/image_field.py
+++ b/insalan/components/image_field.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from django.core.exceptions import ValidationError
 from django.db import models
 from PIL import Image
+import pillow_avif
 
 class ImageField(models.ImageField):
     """
@@ -21,7 +22,7 @@ class ImageField(models.ImageField):
         if self.convert_to_webp:
             try:
                 img = Image.open(file)
-                if img.format != "WEBP":
+                if img.format not in ["WEBP", "AVIF"]:
                     buffer = BytesIO()
                     img.save(buffer, format="WEBP")
                     buffer.seek(0)

--- a/insalan/partner/models.py
+++ b/insalan/partner/models.py
@@ -4,6 +4,8 @@ from django.core.validators import FileExtensionValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from insalan.components.image_field import ImageField
+
 class Partner(models.Model):
     class PartnerType(models.TextChoices):
         """There are two types of sponsors"""
@@ -22,7 +24,7 @@ class Partner(models.Model):
         max_length=200, verbose_name=_("Nom du partenaire/sponsor")
     )
     url: models.URLField = models.URLField(verbose_name=_("URL"))
-    logo: models.FileField = models.FileField(
+    logo: models.FileField = ImageField(
         verbose_name=_("Logo"),
         upload_to="partners",
         validators=[

--- a/insalan/partner/models.py
+++ b/insalan/partner/models.py
@@ -28,7 +28,7 @@ class Partner(models.Model):
         verbose_name=_("Logo"),
         upload_to="partners",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
     partner_type: models.CharField = models.CharField(

--- a/insalan/partner/tests.py
+++ b/insalan/partner/tests.py
@@ -18,6 +18,8 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
 
 from insalan.user.models import User
 
@@ -35,9 +37,17 @@ def create_test_img(file_name: str = "test.png") -> SimpleUploadedFile:
     """
     Create a test image file.
     """
-    test_img = io.BytesIO(b"test image")
+    # Create an image using Pillow
+    image = Image.new('RGB', (100, 100), color = (73, 109, 137))
+
+    # Save the image to a BytesIO object
+    test_img = io.BytesIO()
+    image.save(test_img, format='PNG')
+    test_img.seek(0)
     test_img.name = file_name
-    return SimpleUploadedFile(test_img.name, test_img.getvalue())
+
+    # Return the SimpleUploadedFile object
+    return SimpleUploadedFile(test_img.name, test_img.getvalue(), content_type='image/png')
 
 
 class UserTestCase(TestCase):

--- a/insalan/pizza/models.py
+++ b/insalan/pizza/models.py
@@ -15,6 +15,8 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField
 
+from insalan.components.image_field import ImageField
+
 class PaymentMethod(models.TextChoices):
     """
     Payment method choices
@@ -52,7 +54,7 @@ class Pizza(models.Model):
         blank=True,
         null=True,
     )
-    image: models.FileField = models.FileField(
+    image: models.FileField = ImageField(
         verbose_name=_("Image"),
         upload_to="pizzas",
         validators=[

--- a/insalan/pizza/models.py
+++ b/insalan/pizza/models.py
@@ -58,7 +58,7 @@ class Pizza(models.Model):
         verbose_name=_("Image"),
         upload_to="pizzas",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
         null=True,
         blank=True,

--- a/insalan/tournament/management/commands/populate.py
+++ b/insalan/tournament/management/commands/populate.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
         test_img.name = (
             generate_garbage(randint(5, 20))
             + "."
-            + choice(["png", "jpg", "jpeg", "svg", "webp"])
+            + choice(["png", "jpg", "jpeg", "svg", "webp", "avif"])
         )
         return SimpleUploadedFile(test_img.name, test_img.getvalue())
 

--- a/insalan/tournament/models/caster.py
+++ b/insalan/tournament/models/caster.py
@@ -20,7 +20,7 @@ class Caster(models.Model):
         null=True,
         upload_to="profile-pictures",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
     tournament = models.ForeignKey(

--- a/insalan/tournament/models/caster.py
+++ b/insalan/tournament/models/caster.py
@@ -2,6 +2,8 @@ from django.db import models
 from django.core.validators import FileExtensionValidator
 from django.utils.translation import gettext_lazy as _
 
+from insalan.components.image_field import ImageField
+
 class Caster(models.Model):
     """
     A Caster is someone that can cast a tournament.
@@ -12,7 +14,7 @@ class Caster(models.Model):
         blank=False,
         verbose_name=_("Nom du casteur")
     )
-    image = models.FileField(
+    image = ImageField(
         verbose_name=_("Photo de profil"),
         blank=True,
         null=True,

--- a/insalan/tournament/models/event.py
+++ b/insalan/tournament/models/event.py
@@ -10,6 +10,8 @@ from django.utils.translation import gettext_lazy as _
 
 from . import tournament
 
+from insalan.components.image_field import ImageField
+
 class Event(models.Model):
     """
     An Event is any single event that is characterized by the following:
@@ -41,7 +43,7 @@ class Event(models.Model):
         validators=[MinValueValidator(1), MaxValueValidator(12)],
     )
     ongoing = models.BooleanField(verbose_name=_("En cours"), default=False)
-    logo: models.FileField = models.FileField(
+    logo: models.FileField = ImageField(
         verbose_name=_("Logo"),
         blank=True,
         null=True,

--- a/insalan/tournament/models/event.py
+++ b/insalan/tournament/models/event.py
@@ -49,7 +49,7 @@ class Event(models.Model):
         null=True,
         upload_to="event-icons",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
 

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -58,7 +58,7 @@ class Tournament(models.Model):
         null=True,
         upload_to="tournament-icons",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
     # Tournament player slot prices

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from django.contrib.postgres.fields import ArrayField
 
 from . import team, caster, group, bracket, swiss
+from insalan.components.image_field import ImageField
 
 def in_thirty_days():
     """Return now + 30 days"""
@@ -51,7 +52,7 @@ class Tournament(models.Model):
         default=in_thirty_days,
         null=False,
     )
-    logo: models.FileField = models.FileField(
+    logo: models.FileField = ImageField(
         verbose_name=_("Logo"),
         blank=True,
         null=True,

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -83,7 +83,7 @@ class User(AbstractUser, PermissionsMixin):
         null=True,
         upload_to="profile-pictures",
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
 

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -11,6 +11,8 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.core.validators import FileExtensionValidator
 
+from insalan.components.image_field import ImageField
+
 class UserManager(BaseUserManager):
     """
     Managers the User objects (kind of like a serializer but not quite that)
@@ -75,7 +77,7 @@ class User(AbstractUser, PermissionsMixin):
     USERNAME_FIELD = "username"
     EMAIL_FIELD = "email"
 
-    image = models.FileField(
+    image = ImageField(
         verbose_name=_("photo de profil"),
         blank=True,
         null=True,

--- a/insalan/user/serializers.py
+++ b/insalan/user/serializers.py
@@ -45,7 +45,7 @@ class UserRegisterSerializer(serializers.ModelSerializer):
     image = serializers.FileField(
         required=False,
         validators=[
-            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp"])
+            FileExtensionValidator(allowed_extensions=["png", "jpg", "jpeg", "svg", "webp", "avif"])
         ],
     )
     name = serializers.CharField(write_only=True, required=False, allow_blank=True) #If this field is filled, something bad happened (bot), purposely ambiguous nament

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ reportlab==4.0.9
 pillow==10.2.0 
 APScheduler==3.10.4
 drf-yasg==1.21.7
+pillow-avif-plugin==1.4.6


### PR DESCRIPTION
## Description

This pull request introduces a custom `ImageField` that converts images to the webp format and updates various models to use this new field.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.


## Related Issues

Fix #174 