### PR TITLE
Add DELETE method for pizza export

### DIFF
--- a/insalan/pizza/urls.py
+++ b/insalan/pizza/urls.py
@@ -44,4 +44,5 @@ urlpatterns = [
    path("order/", views.OrderList.as_view(), name="order/list"),
    path("order/full/", views.OrderListFull.as_view(), name="order/list/full"),
    path("order/<int:pk>/", views.OrderDetail.as_view(), name="order/detail"),
+   path("export/<int:pk>/", views.ExportOrderDelete.as_view(), name="export/delete"),
 ]

--- a/insalan/pizza/views.py
+++ b/insalan/pizza/views.py
@@ -769,3 +769,38 @@ class ExportOrder(generics.ListCreateAPIView):
 
         # return the export (using get)
         return self.get(request, *args, **kwargs)
+
+class ExportOrderDelete(generics.DestroyAPIView):
+    """Delete an export by its id."""
+
+    pagination_class = None
+    queryset = PizzaExport.objects.all()
+    permission_classes = [permissions.IsAdminUser | ReadOnly]
+    serializer_class = serializers.PizzaExportSerializer
+
+    @swagger_auto_schema(
+        responses={
+            204: openapi.Response(description=_("Export supprimé.")),
+            403: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "detail": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Vous n'êtes pas autorisé à supprimer cet export.")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "detail": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Export non trouvé.")
+                    )
+                }
+            )
+        }
+    )
+    def delete(self, request, *args, **kwargs):
+        """Delete an export."""
+        return super().delete(request, *args, **kwargs)


### PR DESCRIPTION
## Description

Add the DELETE method for the pizza export to be able to delete exports from the frontend.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

This will be needed for [Manage exports from fronts #119 ](https://github.com/InsaLan/frontend-insalan.fr/issues/119).

