### PR TITLE
Fix teamslot not being editable from admin panel

### DIFF
--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -29,6 +29,7 @@ from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters
+from django.db.models import Q
 
 from insalan.mailer import MailManager
 from insalan.tournament.manage import (
@@ -411,7 +412,7 @@ class TeamForm(forms.ModelForm):
             seat_slot.queryset = seat_slot.queryset.filter(
                 tournament=self.instance.tournament
             ).filter(
-                team=None
+                Q(team=None) | Q(team=self.instance)
             )
 
     def clean(self):

--- a/insalan/tournament/models/seat_slot.py
+++ b/insalan/tournament/models/seat_slot.py
@@ -20,6 +20,9 @@ class SeatSlot(models.Model):
         verbose_name=_("Place"),
     )
 
+    def __str__(self):
+        return f"SeatSlot {self.id} for {self.tournament.name}"
+
     class Meta:
         """Meta Options"""
 


### PR DESCRIPTION
## Description

On team edition, slot field was always None.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [N/A] I have added tests to cover my changes.
- [N/A] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.


## Related Issues

Fix #188 
