### PR TITLE
Use pytest instead of Django's tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,4 +88,4 @@ jobs:
       - run: python3 manage.py makemigrations
       - run: python3 manage.py migrate
 
-      - run: pytest
+      - run: pytest -n auto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
 
       # Install dependencies
       - run: pip3 install -r requirements.txt
+      - run: pip3 install -r requirements-dev.txt
 
       # Initialize the database
       - run: psql postgresql://${{ env.DB_USER }}:${{ env.DB_PASS }}@${{ env.DB_HOST }}:${{ env.DB_PORT }}/${{ env.DB_NAME }} -f .github/workflows/init_db.sql
@@ -87,4 +88,4 @@ jobs:
       - run: python3 manage.py makemigrations
       - run: python3 manage.py migrate
 
-      - run: python3 manage.py test --parallel auto
+      - run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ insalan/static/partners
 
 # Translation files
 locale/**/*.mo
+
+# Runtime stuff
+v1/*

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,14 +1,16 @@
 FROM python:3.12-alpine3.19
 
 EXPOSE 8000
-WORKDIR /app
+WORKDIR /backend
 
-RUN apk add --no-cache postgresql15-dev gcc musl-dev
+RUN apk add --no-cache postgresql15-dev gcc musl-dev fish git
 
-COPY requirements.txt /app/
-COPY requirements-dev.txt /app/
+ENV SHELL=/usr/bin/fish
 
-RUN pip install -r /app/requirements.txt
-RUN pip install -r /app/requirements-dev.txt
+COPY requirements.txt /backend/
+COPY requirements-dev.txt /backend/
+
+RUN pip install -r /backend/requirements.txt
+RUN pip install -r /backend/requirements-dev.txt
 
 ENTRYPOINT ["./entrypoint-dev.sh"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = insalan.settings
+python_files = tests.py test_*.py *_tests.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,5 @@
 pylint==3.0.3
 pylint-django==2.6.1
+tblib==3.1.0
+pytest==8.4.2
+pytest-django==4.11.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pylint-django==2.6.1
 tblib==3.1.0
 pytest==8.4.2
 pytest-django==4.11.1
+pytest-xdist==3.8.0


### PR DESCRIPTION
## Description

This PR replaces the way we do tests (`python manage.py test`) with pytest using the `django-pytest` module. This makes the testing procedure more standard, which will allow tests to integrate with IDEs like VSCode (when used with InsaLan/infra-insalan.fr#34).

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [N/A] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [N/A] I have added labels to the pull request, if necessary.
