### PR TITLE
Get user first and last name from HelloAsso payment callback

### DIFF
--- a/docs/manuel/src/00-prelude/prerequis.md
+++ b/docs/manuel/src/00-prelude/prerequis.md
@@ -120,9 +120,9 @@ on appelle souvent ces bases de données des bases **NoSQL**.
 Toute notre gestion du code passe par l'utilisation de `git`. C'est un outil
 extrêmement puissant, mais qu'il est trop long de décrire. Il existe
 heureusement une
-[formation](https://git.vulpinecitrus.info/Lymkwi/surviving-git/src/branch/master/build/default/default.pdf)
+[formation](https://github.com/InsaLan/doc/blob/main/Formations/Git/complete/main.pdf)
 qui permet de se familiariser avec les commandes de base de `git` et pourquoi
-elles fonctionnent comme elles fonctionnes.
+elles fonctionnent comme elles fonctionnent.
 
 L'idée globale cependant: `git` permet de capturer des sauvegardes successives
 de notre code, et de les associer à du texte pour expliquer les modifications

--- a/docs/manuel/src/03-existant/modules/payment.md
+++ b/docs/manuel/src/03-existant/modules/payment.md
@@ -7,46 +7,61 @@ c'est important de comprendre comment ça marche, parce que c'est un peu le nerf
 de la guerre. Pas de paiements, pas d'inscription. Pas d'inscription, pas de
 LAN. Pas de LAN, pas de LAN.
 
+## Modèles
+
 Les modèles de ce module sont assez compliqués parce qu'ils dépendent de notre
-prestataire de paiement, HelloAsso. On a donc un modèle `Product` qui représente
-un produit achetable (un tournoi, un repas, une place de LAN, etc.), un modèle
-`Transaction` qui représente une transaction (un paiement), et un modèle
-`Payment` qui représente un paiement (un paiement).
+prestataire de paiement, **HelloAsso**.
 
-## Product
+### Product
 
-Les produits n'on pas à être créés manuellement, ils sont générés
-automatiquement à la création d'un tournoi (et plus tard, d'un créneau pizza).
+Ces objets représentent des produit achetables (un tournoi, un repas, une place de LAN, etc.). Ils n'ont pas à être créés manuellement, ils sont **générés
+automatiquement** à la création d'un tournoi (et plus tard, d'un créneau pizza).
 Ils contiennent plusieurs info comme le nom, le prix, la description, les dates
 de début et de fin de vente, etc.
 
-## Discount
+### Discount
 
 Les réductions sont créées manuellement par les admins. Elles font le lien entre
-un utilisateur et un produit. La valeur de la réduction et une description sont
+un utilisateur·rice et un produit. La valeur de la réduction et une description sont
 également stockées dans ce modèle. Les réductions doivent être ajoutés en amont
 du paiement et peuvent être utilisées une seule fois. Cela peut permettre de
 réduire le prix d'un pour certains joueurs. 
 
-## Transaction
+### Transaction
 
-Les transactions sont créées à chaque fois qu'un utilisateur initie un paiement
+Les transactions sont créées à chaque fois qu'un utilisateur·rice **initie un paiement**
 avec HelloAsso. Elles contiennent des informations sur le paiement, comme le
-montant, le produit acheté, l'utilisateur qui a acheté, etc. Une transaction
-peut très bien ne pas être suivie d'un paiement, si l'utilisateur abandonne le
+montant, le produit acheté, l'utilisateur·rice qui a acheté, etc. Une transaction
+peut très bien ne pas être suivie d'un paiement, si l'utilisateur·rice abandonne le
 paiement en cours de route.
 
-## Payment
+### Payment
 
-Les paiements sont créés à chaque fois qu'un utilisateur a payé un produit. Ils
+Les paiements sont créés à chaque fois qu'un utilisateur·rice **a payé un produit**. Ils
 contiennent des informations sur le paiement, comme le montant, le produit
-acheté, l'utilisateur qui a acheté, etc. Attention, un paiement peut se
-transformer en remboursement si l'utilisateur annule son achat.
+acheté, l'utilisateur·rice qui a acheté, etc. Attention, un paiement peut se
+transformer en remboursement si l'utilisateur·rice annule son achat.
 
-## HelloAsso
+## Procédure de paiement
+
+### API HelloAsso
 
 HelloAsso est notre prestataire de paiement. C'est une plateforme qui permet de
 faire des paiements en ligne, et qui est spécialisée pour les associations.
-Cette brique est techniquement changeable pour une autre (si jamais l'amicale
-décide de forcer pour utiliser Lifpay) mais pour l'instant, c'est HelloAsso qui
+Cette brique est techniquement **changeable pour une autre** (si jamais l'amicale
+décide de forcer pour utiliser Lyfpay) mais pour l'instant, c'est HelloAsso qui
 nous convient le mieux.
+
+Pour envoyer une demande de paiement, on utilise l'**API HelloAsso**, dont les clés sont normalement dans le `.env`. Sa documentation peut être trouvée [ici](https://dev.helloasso.com/docs/introduction-%C3%A0-lapi-de-helloasso).
+
+### PayView
+
+La vue PayView, déclarée dans `insalan/payment/views.py` est celle qui s'occupe de déclarer un **"checkout intent"**. Cet intent est celui qui déclare une demande de paiement faite à un utilisateur·rice, et il est envoyé sous la forme d'une requête POST sur https://api.helloasso.com/v5/organizations/insalan/checkout-intents. C'est cette vue qui est appelée par le front quand l'utilisateur·rice clique sur le bouton "Payer" de son panier. Cette vue est aussi celle qui crée l'objet `Transaction` lié au paiement.
+
+### Notifications
+
+L'API HelloAsso communique avec notre site par "notifications", des requêtes POST envoyées sur une addresse spécifiée dans les paramètres du compte HelloAsso de l'InsaLan. En l'occurence, il s'agit de https://api.insalan.fr/v1/payment/notifications, et de la vue `Notifications`. Ces notifications peuvent concerner plusieurs choses, comme des changements apportés au compte HelloAsso, ou au fonctionnement d'HelloAsso en lui-même.
+
+Cependant, les notifications qui nous intéressent vraiment sont celles concernant les paiements. Tout d'abord, une fois que l'utilisateur·rice a **validé ses informations de paiement**, une première notification comme [celle-ci](https://dev.helloasso.com/docs/notification-exemple#commandes-cr%C3%A9%C3%A9-sur-un-paiement-checkout-avec-des-%C3%A9ch%C3%A9ances) avec `eventType = "Order"` est envoyée. Celle-ci crée l'objet `Payment` du paiement. C'est aussi lors du traitement de cette notification qu'on récupère le nom du·de la joueur·euse, qui nous sera utile pour vérifier saon identité à l'entrée. On met aussi `confirm_name` à `True` pour qu'iel confirme que c'est bien saon identité.
+
+Ensuite, lorsque **la carte a bien été débitée** et que la thune du·de la joueur·euse est officiellement la notre, une notification de [ce genre](https://dev.helloasso.com/docs/notification-exemple#paiement-autoris%C3%A9-sur-un-checkout) est envoyée. C'est celle-ci qui va venir valider la `Transaction` (ou l'invalider, puisque ces notifications informent aussi des éventuelles erreurs comme les paiements refusés).

--- a/insalan/payment/views.py
+++ b/insalan/payment/views.py
@@ -291,6 +291,22 @@ class Notifications(APIView):
             trans_obj.touch()
             trans_obj.save()
 
+            # Retrieve the payer's name which will be useful for the event
+            payer = trans_obj.payer
+            if payer is not None:
+                data_first_name = data.get("payer", {}).get("firstName", "")
+                data_last_name = data.get("payer", {}).get("lastName", "")
+                modified = False
+                if data_first_name != "" and payer.first_name == "":
+                    payer.first_name = data_first_name
+                    modified = True
+                if data_last_name != "" and payer.last_name == "":
+                    payer.last_name = data_last_name
+                    modified = True
+                if modified or payer.first_name == "" or payer.last_name == "":
+                    payer.confirm_name = True
+                payer.save()
+
             payments = data.get("payments")
             if payments is None:
                 logger.warning(
@@ -383,21 +399,6 @@ class Notifications(APIView):
             state = data.get("state")
             if state == "Authorized":
                 # Ok we should be good now
-                # Retrieve the payer's name which will be useful for the event
-                payer = trans_obj.payer
-                if payer is not None:
-                    data_first_name = data.get("payer", {}).get("firstName", "")
-                    data_last_name = data.get("payer", {}).get("lastName", "")
-                    modified = False
-                    if data_first_name != "" and payer.first_name == "":
-                        payer.first_name = data_first_name
-                        modified = True
-                    if data_last_name != "" and payer.last_name == "":
-                        payer.last_name = data_last_name
-                        modified = True
-                    if modified or payer.first_name == "" or payer.last_name == "":
-                        payer.confirm_name = True
-                    payer.save()
                 trans_obj.validate_transaction()
 
             elif state in ["Refused", "Unknown"]:

--- a/insalan/payment/views.py
+++ b/insalan/payment/views.py
@@ -385,13 +385,19 @@ class Notifications(APIView):
                 # Ok we should be good now
                 # Retrieve the payer's name which will be useful for the event
                 payer = trans_obj.payer
-                data_first_name = data.get("payer", {}).get("firstName", "")
-                data_last_name = data.get("payer", {}).get("lastName", "")
-                if data_first_name != "" and payer.first_name == "":
-                    payer.first_name = data_first_name
-                if data_last_name != "" and payer.last_name == "":
-                    payer.last_name = data_last_name
-                payer.save()
+                if payer is not None:
+                    data_first_name = data.get("payer", {}).get("firstName", "")
+                    data_last_name = data.get("payer", {}).get("lastName", "")
+                    modified = False
+                    if data_first_name != "" and payer.first_name == "":
+                        payer.first_name = data_first_name
+                        modified = True
+                    if data_last_name != "" and payer.last_name == "":
+                        payer.last_name = data_last_name
+                        modified = True
+                    if modified or payer.first_name == "" or payer.last_name == "":
+                        payer.confirm_name = True
+                    payer.save()
                 trans_obj.validate_transaction()
 
             elif state in ["Refused", "Unknown"]:

--- a/insalan/payment/views.py
+++ b/insalan/payment/views.py
@@ -383,6 +383,15 @@ class Notifications(APIView):
             state = data.get("state")
             if state == "Authorized":
                 # Ok we should be good now
+                # Retrieve the payer's name which will be useful for the event
+                payer = trans_obj.payer
+                data_first_name = data.get("payer", {}).get("firstName", "")
+                data_last_name = data.get("payer", {}).get("lastName", "")
+                if data_first_name != "" and payer.first_name == "":
+                    payer.first_name = data_first_name
+                if data_last_name != "" and payer.last_name == "":
+                    payer.last_name = data_last_name
+                payer.save()
                 trans_obj.validate_transaction()
 
             elif state in ["Refused", "Unknown"]:

--- a/insalan/user/admin.py
+++ b/insalan/user/admin.py
@@ -99,7 +99,15 @@ class CustomUserAdmin(UserAdmin):
         (
             "Informations personnelles",
             {
-                'fields': ('first_name', 'last_name', 'email', 'display_name', 'pronouns','status'),
+                'fields': (
+                    'first_name',
+                    'last_name',
+                    'confirm_name',
+                    'email',
+                    'display_name',
+                    'pronouns',
+                    'status'
+                ),
             },
         ),
         (

--- a/insalan/user/models.py
+++ b/insalan/user/models.py
@@ -103,6 +103,9 @@ class User(AbstractUser, PermissionsMixin):
     )
     first_name = models.CharField(max_length=50, blank=True)
     last_name = models.CharField(max_length=50, blank=True)
+    confirm_name = models.BooleanField(
+        verbose_name="Ask to confirm name next time the user logs in", default=False
+    )
     display_name = models.CharField(max_length=50, blank=True)
     pronouns = models.CharField(max_length=20, blank=True, null=False, default="")
     status = models.CharField(max_length=100, blank=True, null=False, default="")

--- a/insalan/user/views.py
+++ b/insalan/user/views.py
@@ -222,6 +222,9 @@ class UserMe(generics.RetrieveAPIView[User]):  # pylint: disable=unsubscriptable
         if "last_name" in data:
             user.last_name = data["last_name"]
 
+        if "confirm_name" in data:
+            user.confirm_name = data["confirm_name"]
+
         if "display_name" in data:
             user.display_name = data["display_name"]
 


### PR DESCRIPTION
## Description

This PR automatically gets the payer's first and last name from [the HelloAsso callback](https://dev.helloasso.com/docs/notification-exemple#paiement-autoris%C3%A9-sur-un-checkout) when they pay, if they haven't filled those fields already. This will also enable the `confirm_name` property for InsaLan/frontend-insalan.fr#201.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [N/A] I have added tests to cover my changes. see #183 
- [x] I have updated the documentation accordingly.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.

## Related Issues

Fix #155 
Fix #200