### PR TITLE
Fix syntax error in tournament admin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Install Python 3.12
+      # Install Python 3.11
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       # Set the environment up
       - run: python3 -m venv env
@@ -45,10 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Install Python 3.12
+      # Install Python 3.11
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       # Set the environment up
       - run: python3 -m venv env
@@ -87,10 +87,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Install Python 3.12
+      # Install Python 3.11
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
 
       # Set the environment up
       - run: python3 -m venv env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.19
+FROM python:3.11-alpine3.19
 
 EXPOSE 8000
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine3.19
+FROM python:3.11-alpine3.19
 
 EXPOSE 8000
 WORKDIR /app

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -1062,11 +1062,11 @@ class SubstituteAdmin(ModelAdmin):  # type: ignore
         msg = _("The name in game was successfully updated to ") + substitute.name_in_game + "."
         messages.success(request, msg)
 
+        app_label = substitute._meta.app_label
+        model_name = substitute._meta.model_name
         return HttpResponseRedirect(
             reverse(
-                f"{self.admin_site.name}:{
-                    substitute._meta.app_label
-                }_{substitute._meta.model_name}_change",
+                f"{self.admin_site.name}:{app_label}_{model_name}_change",
                 args=(substitute.pk,),
             )
         )


### PR DESCRIPTION
## Description

When launching the backend with python 3.11 (the version we're still using in prod), it triggers a syntax error due to a multiline fstring that were not supported. This PR fix this error.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.