### PR TITLE
Add the possibility to disable manager registration in an event tournament

### DIFF
--- a/insalan/tournament/models/manager.py
+++ b/insalan/tournament/models/manager.py
@@ -74,7 +74,8 @@ class Manager(models.Model):
     def clean(self) -> None:
         """
         Assert that the user associated with the provided manager does not already
-        exist in any team of any tournament of the event
+        exist in any team of any tournament of the event and that the tournament
+        allow manager registration.
         """
         user = self.user
         tourney = self.get_team().get_tournament()
@@ -86,3 +87,5 @@ class Manager(models.Model):
                 )
             if not validators.tournament_announced(tourney):
                 raise ValidationError(_("Tournoi non annoncé"))
+            if not tourney.enable_manager:
+                raise ValidationError(_("Ce tournoi n'autorise pas l'inscription de manager"))

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -217,6 +217,10 @@ class EventTournament(BaseTournament):
         default=in_thirty_days,
         null=False,
     )
+    enable_manager = models.BooleanField(
+        verbose_name=_("Activer les places manager"),
+        default=True,
+    )
     # Tournament player slot prices
     # These prices are used at the tournament creation to create associated
     # products
@@ -351,22 +355,23 @@ class EventTournament(BaseTournament):
         self.player_online_product.available_until = self.registration_close
         self.player_online_product.save()
 
-        if self.manager_online_product is None:
-            prod = Product.objects.create(
-                price=self.manager_price_online,
-                name=cast(str, _(f"Place {self.name} manager en ligne - {self.event.name}")),
-                desc=cast(str, _(f"Inscription au tournoi {self.name} manager")),
-                category=ProductCategory.REGISTRATION_MANAGER,
-                associated_tournament=self,
-                available_from=self.registration_open,
-                available_until=self.registration_close,
-            )
-            self.manager_online_product = prod
-            need_save = True
+        if self.enable_manager:
+            if self.manager_online_product is None:
+                prod = Product.objects.create(
+                    price=self.manager_price_online,
+                    name=cast(str, _(f"Place {self.name} manager en ligne - {self.event.name}")),
+                    desc=cast(str, _(f"Inscription au tournoi {self.name} manager")),
+                    category=ProductCategory.REGISTRATION_MANAGER,
+                    associated_tournament=self,
+                    available_from=self.registration_open,
+                    available_until=self.registration_close,
+                )
+                self.manager_online_product = prod
+                need_save = True
 
-        self.manager_online_product.available_from = self.registration_open
-        self.manager_online_product.available_until = self.registration_close
-        self.manager_online_product.save()
+            self.manager_online_product.available_from = self.registration_open
+            self.manager_online_product.available_until = self.registration_close
+            self.manager_online_product.save()
 
         if self.substitute_online_product is None:
             prod = Product.objects.create(

--- a/insalan/tournament/test/test_event.py
+++ b/insalan/tournament/test/test_event.py
@@ -298,6 +298,7 @@ class EventDerefAndGroupingEndpoints(APITestCase):
                         timezone.make_naive(tourney.registration_close)
                     ).isoformat(),
                     "logo": None,
+                    "enable_manager": True,
                     "player_price_online": "0.00",
                     "player_price_onsite": "0.00",
                     "manager_price_online": "0.00",

--- a/insalan/tournament/test/test_event_tournament.py
+++ b/insalan/tournament/test/test_event_tournament.py
@@ -275,6 +275,7 @@ class TournamentFullDerefEndpoint(APITestCase):
             "registration_close": timezone.make_aware(
                 timezone.make_naive(tourneyobj_one.registration_close)
             ).isoformat(),
+            "enable_manager": True,
             "player_price_online": "0.00",
             "player_price_onsite": "0.00",
             "manager_price_online": "0.00",


### PR DESCRIPTION
## Description

This year, there will be no manager at the Lan, so this PR add a way to disable manager registration for a tournament.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

