### PR TITLE
Add game processor

### DIFF
--- a/assets/css/collapsible_json.css
+++ b/assets/css/collapsible_json.css
@@ -1,0 +1,52 @@
+/**
+ * Styles for collapsible JSON viewer in Django admin
+ */
+
+.collapsible-json-container {
+    margin: 10px 0;
+}
+
+.collapsible-json-toggle {
+    background: #2563eb;
+    color: white;
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    margin-bottom: 8px;
+    transition: background 0.2s ease;
+}
+
+.collapsible-json-toggle:hover {
+    background: #1d4ed8;
+}
+
+.collapsible-json-toggle:active {
+    background: #1e40af;
+}
+
+.collapsible-json-content {
+    display: none;
+    background: #1e293b;
+    color: #e2e8f0;
+    padding: 16px;
+    border-radius: 4px;
+    overflow-x: auto;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+    font-size: 13px;
+    line-height: 1.6;
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.collapsible-json-content pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+.collapsible-json-empty {
+    color: #94a3b8;
+    font-style: italic;
+}

--- a/assets/js/collapsible_json.js
+++ b/assets/js/collapsible_json.js
@@ -19,7 +19,11 @@
         }
 
         toggle.addEventListener('click', function() {
-            if (content.style.display === 'none') {
+            // Check computed style instead of inline style to handle CSS-defined display
+            const isHidden = content.style.display === 'none' || 
+                           window.getComputedStyle(content).display === 'none';
+            
+            if (isHidden) {
                 content.style.display = 'block';
                 toggle.textContent = 'Masquer JSON';
             } else {

--- a/assets/js/collapsible_json.js
+++ b/assets/js/collapsible_json.js
@@ -1,0 +1,63 @@
+/**
+ * Collapsible JSON viewer for Django admin
+ * Automatically initializes all collapsible JSON elements on the page
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Initialize a single collapsible JSON element
+     * @param {string} widgetId - The unique ID for this widget instance
+     */
+    function initCollapsibleJson(widgetId) {
+        const toggle = document.getElementById(widgetId + '_toggle');
+        const content = document.getElementById(widgetId + '_content');
+        
+        if (!toggle || !content) {
+            return;
+        }
+
+        toggle.addEventListener('click', function() {
+            if (content.style.display === 'none') {
+                content.style.display = 'block';
+                toggle.textContent = 'Masquer JSON';
+            } else {
+                content.style.display = 'none';
+                toggle.textContent = 'Afficher JSON';
+            }
+        });
+    }
+
+    /**
+     * Initialize all collapsible JSON elements on the page
+     */
+    function initAllCollapsibleJson() {
+        // Find all toggle buttons with IDs matching the pattern
+        const toggleButtons = document.querySelectorAll('[id$="_toggle"]');
+        
+        toggleButtons.forEach(function(button) {
+            const buttonId = button.id;
+            if (buttonId.startsWith('json_api_data_') && buttonId.endsWith('_toggle')) {
+                // Extract the widget ID (remove '_toggle' suffix)
+                const widgetId = buttonId.slice(0, -7);
+                initCollapsibleJson(widgetId);
+            }
+        });
+    }
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initAllCollapsibleJson);
+    } else {
+        // DOM is already ready
+        initAllCollapsibleJson();
+    }
+
+    // Re-initialize when Django admin uses inline forms (for dynamic forms)
+    if (typeof django !== 'undefined' && django.jQuery) {
+        django.jQuery(document).on('formset:added', function() {
+            initAllCollapsibleJson();
+        });
+    }
+})();

--- a/assets/js/game_parameters.js
+++ b/assets/js/game_parameters.js
@@ -1,0 +1,86 @@
+/**
+ * Game Parameters Widget JavaScript
+ * Handles form submission for game parameter fields
+ */
+
+(function() {
+    'use strict';
+
+    /**
+     * Initialize game parameters form handling for a specific widget
+     * @param {string} fieldName - The name of the hidden field
+     * @param {Object} schema - The parameter schema with field types
+     */
+    function initGameParameters(fieldName, schema) {
+        var hiddenField = document.getElementById('id_' + fieldName);
+        if (!hiddenField) {
+            return;
+        }
+
+        var form = hiddenField.closest('form');
+        if (!form) {
+            return;
+        }
+
+        // Add submit event listener
+        form.addEventListener('submit', function() {
+            var params = {};
+            
+            // Collect values from all parameter fields
+            for (var paramName in schema) {
+                if (schema.hasOwnProperty(paramName)) {
+                    var fieldId = 'param_' + paramName;
+                    var field = document.getElementById(fieldId);
+                    var paramType = schema[paramName].type || 'string';
+                    
+                    if (field) {
+                        if (paramType === 'bool') {
+                            params[paramName] = field.checked;
+                        } else if (paramType === 'int') {
+                            params[paramName] = parseInt(field.value, 10);
+                        } else {
+                            params[paramName] = field.value;
+                        }
+                    }
+                }
+            }
+            
+            // Update hidden field with JSON string
+            hiddenField.value = JSON.stringify(params);
+        });
+    }
+
+    /**
+     * Initialize all game parameter widgets on the page
+     */
+    function initAllGameParameters() {
+        var widgets = document.querySelectorAll('[data-game-parameters]');
+        widgets.forEach(function(widget) {
+            var fieldName = widget.getAttribute('data-field-name');
+            var schemaJson = widget.getAttribute('data-schema');
+            
+            if (fieldName && schemaJson) {
+                try {
+                    var schema = JSON.parse(schemaJson);
+                    initGameParameters(fieldName, schema);
+                } catch (e) {
+                    console.error('Failed to parse game parameters schema:', e);
+                }
+            }
+        });
+    }
+
+    // Initialize on page load
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initAllGameParameters);
+    } else {
+        initAllGameParameters();
+    }
+
+    // Support for Django inline forms
+    if (typeof django !== 'undefined' && django.jQuery) {
+        django.jQuery(document).on('formset:added', function() {
+            initAllGameParameters();
+        });
+    }
+})();

--- a/docs/manuel/src/03-existant/game-processor.md
+++ b/docs/manuel/src/03-existant/game-processor.md
@@ -1,0 +1,109 @@
+# Game Processor
+
+## Introduction
+
+Le système de **Game Processor** (ou "processeur de jeu") est un mécanisme
+d'automatisation qui permet de gérer automatiquement les tournois pour certains
+jeux via leurs APIs officielles. Concrètement, ça évite de devoir créer les
+lobbies manuellement, récupérer les résultats, et mettre à jour les scores à la
+main.
+
+Actuellement, le système supporte :
+- **League of Legends** via l'API Tournament v5 de Riot Games
+- **Mode vide** pour les jeux sans automatisation
+
+## Architecture
+
+### Classe Abstraite `GameProcessor`
+
+Tous les processeurs de jeu héritent de la classe abstraite `GameProcessor` qui
+définit les hooks (points d'entrée) suivants :
+
+```python
+class GameProcessor(ABC):
+    short: ClassVar[str]  # Identifiant court (ex: "LoL")
+    name: ClassVar[StrPromise]  # Nom affiché (ex: "League of Legends")
+    
+    # Paramètres configurables
+    default_game_parameters: ClassVar[dict[str, Any]] = {}
+    game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
+    
+    # Hooks du cycle de vie
+    @abstractmethod
+    def initialize_tournament(tournament: BaseTournament) -> dict[str, Any] | None
+    
+    @abstractmethod
+    def update_tournament(tournament: BaseTournament) -> dict[str, Any] | None
+    
+    @abstractmethod
+    def create_match(match: Match) -> dict[str, Any] | None
+    
+    @abstractmethod
+    def start_match(match: Match) -> dict[str, Any] | None
+    
+    @abstractmethod
+    def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None
+    
+    @abstractmethod
+    def delete_match(match: Match) -> None
+```
+
+### Cycle de Vie d'un Tournoi
+
+```
+1. Création du Tournament
+   └─> initialize_tournament() appelé automatiquement
+       └─> Récupération des données nécessaires selon le jeu
+
+2. Action admin "Rafraîchir API"
+   └─> update_tournament() appelé manuellement
+       └─> Mise à jour des données API si nécessaire
+
+3. Création d'un Match (bracket/group/swiss)
+   └─> create_match() appelé automatiquement
+       └─> Création de matches via l'API du jeu
+
+4. Démarrage d'un Match
+   └─> start_match() appelé lors du passage en ONGOING
+       └─> Lancement du match via l'API du jeu
+
+5. Réception des Résultats (callback API)
+   └─> process_result_match() appelé par les endpoints /result
+       └─> Mise à jour des scores et progression du tournoi
+
+6. Suppression d'un Match
+   └─> delete_match() appelé lors de la suppression
+       └─> Nettoyage des ressources
+```
+
+### Configuration des Paramètres de Jeu
+
+Chaque processeur peut définir des paramètres configurables via
+`default_game_parameters` et `game_parameters_schema`. Ces paramètres sont
+stockés dans le champ JSON `Game.games_parameters` et peuvent être modifiés dans
+l'admin. Cela permet d'adapter le comportement du processeur selon les besoins
+(ex: type de carte, mode de jeu, etc.).
+
+## Implémentation League of Legends
+
+### Configuration
+
+Le processeur LoL utilise trois paramètres configurables dans
+`Game.games_parameters` :
+
+| Paramètre | Type | Valeurs | Par défaut | Description |
+|-----------|------|---------|------------|-------------|
+| `mapType` | choice | `SUMMONERS_RIFT`, `HOWLING_ABYSS` | `SUMMONERS_RIFT` | Carte de jeu |
+| `pickType` | choice | `BLIND_PICK`, `DRAFT_MODE`, `ALL_RANDOM`, `TOURNAMENT_DRAFT` | `TOURNAMENT_DRAFT` | Mode de sélection |
+| `spectatorType` | choice | `NONE`, `LOBBYONLY`, `ALL` | `ALL` | Type de spectateur |
+
+
+## Configuration dans l'Admin
+
+### Niveau Game
+
+Dans le panel admin, lors de la création/édition d'un `Game` :
+
+1. Sélectionner le **game_processor** (None, LoL, etc.)
+2. Si LoL sélectionné, un widget apparaît pour configurer **games_parameters**
+3. Les paramètres par défaut sont appliqués automatiquement

--- a/docs/manuel/src/SUMMARY.md
+++ b/docs/manuel/src/SUMMARY.md
@@ -43,6 +43,7 @@
         - [payment](./03-existant/modules/payment.md)
         - [pizza](./03-existant/modules/pizza.md)
         - [Écologie](./03-existant/modules/ecology.md)
+    - [Game Processor](./03-existant/game-processor.md)
     - [Traductions](./03-existant/traductions.md)
 
 <!--# Modifier

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -1,7 +1,7 @@
 """Admin handlers for the tournament module"""
 
 import json
-from typing import Any, cast, Type, TypeVar
+from typing import Any, cast, Mapping, Type, TypeVar
 
 from django import forms
 from django.db.models import ForeignKey
@@ -23,8 +23,8 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, resolve, reverse, URLPattern
 from django.utils.decorators import method_decorator
-from django.utils.html import escape, format_html
-from django.utils.safestring import SafeString, mark_safe
+from django.utils.html import escape
+from django.utils.safestring import SafeString
 from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters
 from django.db.models import Q
@@ -67,6 +67,7 @@ from .models import (
     PrivateTournament,
     EventTournament,
     TournamentMailer,
+    game_processor,
 )
 
 
@@ -203,76 +204,110 @@ admin.site.register(Event, EventAdmin)
 class GameParametersWidget(forms.Widget):
     """Custom widget that renders individual fields for game parameters"""
     template_name = ""  # Empty string instead of None for unfold compatibility
-    
-    def __init__(self, schema: dict[str, Any] | None = None, 
+
+    def __init__(self, schema: dict[str, Any] | None = None,
                  defaults: dict[str, Any] | None = None, attrs: dict[str, Any] | None = None):
         super().__init__(attrs)
         self.schema = schema or {}
         self.defaults = defaults or {}
-    
+
     def render(self, name: str, value: Any, attrs: dict[str, Any] | None = None,
                renderer: BaseRenderer | None = None) -> SafeString:
         """Render individual form fields based on schema"""
         if not self.schema:
             return SafeString(f'<input type="hidden" name="{name}" value="{{}}" />')
-        
+
         # Parse current value
         if isinstance(value, str):
-            import json
             try:
                 current_values = json.loads(value) if value else {}
             except (json.JSONDecodeError, TypeError):
                 current_values = {}
         else:
             current_values = value or {}
-        
+
         html_parts = []
         html_parts.append(f'<input type="hidden" name="{name}" id="id_{name}" value="" />')
         html_parts.append('<div style="margin-top: 10px;">')
-        
+
         for param_name, param_info in self.schema.items():
             param_type = param_info.get("type", "string")
             label = param_info.get("label", param_name)
             help_text = param_info.get("help_text", "")
             field_id = f"param_{param_name}"
-            
+
             # Get current or default value
             current_value = current_values.get(param_name)
             if current_value is None and param_name in self.defaults:
                 current_value = self.defaults[param_name]
-            
+
             # Render field
             html_parts.append('<div style="margin-bottom: 20px;">')
-            html_parts.append(f'<label for="{field_id}" class="block text-sm font-medium mb-2">{label}</label>')
-            
+            html_parts.append(
+                f'<label for="{field_id}" class="block text-sm font-medium mb-2">{label}</label>'
+            )
+
             # Common classes for all input fields
-            base_classes = "border border-base-200 bg-white font-medium placeholder-base-400 rounded shadow-sm text-font-default-light text-sm focus:ring focus:ring-primary-300 focus:border-primary-600 focus:outline-none dark:bg-base-900 dark:border-base-700 dark:text-font-default-dark dark:focus:border-primary-600 dark:focus:ring-primary-700 dark:focus:ring-opacity-50 px-3 py-2 w-full"
-            
+            base_classes = (
+                "border border-base-200 bg-white font-medium placeholder-base-400 "
+                "rounded shadow-sm text-font-default-light text-sm focus:ring "
+                "focus:ring-primary-300 focus:border-primary-600 focus:outline-none "
+                "dark:bg-base-900 dark:border-base-700 dark:text-font-default-dark "
+                "dark:focus:border-primary-600 dark:focus:ring-primary-700 "
+                "dark:focus:ring-opacity-50 px-3 py-2 w-full"
+            )
+
             if param_type == "choice":
                 choices = param_info.get("choices", [])
-                html_parts.append(f'<select id="{field_id}" name="{field_id}" class="{base_classes} pr-8 max-w-2xl appearance-none">')
+                select_html = (
+                    '<select id="' + field_id +
+                    '" name="' + field_id +
+                    '" class="' + base_classes +
+                    ' pr-8 max-w-2xl appearance-none">'
+                )
+                html_parts.append(select_html)
                 for choice_value, choice_label in choices:
                     selected = 'selected' if str(current_value) == str(choice_value) else ''
-                    html_parts.append(f'<option value="{choice_value}" {selected}>{choice_label}</option>')
+                    option_html = (
+                        '<option value="' + str(choice_value) + '" ' +
+                        selected + '>' + str(choice_label) + '</option>'
+                    )
+                    html_parts.append(option_html)
                 html_parts.append('</select>')
             elif param_type == "bool":
                 checked = 'checked' if current_value else ''
                 # Checkbox uses different styling
-                checkbox_classes = "rounded border-base-300 text-primary-600 shadow-sm focus:border-primary-300 focus:ring focus:ring-offset-0 focus:ring-primary-200 focus:ring-opacity-50 dark:bg-base-900 dark:border-base-600 dark:checked:bg-primary-600 dark:checked:border-primary-600 dark:focus:ring-offset-base-800"
-                html_parts.append(f'<input type="checkbox" id="{field_id}" name="{field_id}" {checked} class="{checkbox_classes}" />')
+                checkbox_classes = (
+                    "rounded border-base-300 text-primary-600 shadow-sm "
+                    "focus:border-primary-300 focus:ring focus:ring-offset-0 "
+                    "focus:ring-primary-200 focus:ring-opacity-50 dark:bg-base-900 "
+                    "dark:border-base-600 dark:checked:bg-primary-600 "
+                    "dark:checked:border-primary-600 dark:focus:ring-offset-base-800"
+                )
+                html_parts.append(
+                    f'<input type="checkbox" id="{field_id}" name="{field_id}" '
+                    f'{checked} class="{checkbox_classes}" />'
+                )
             elif param_type == "int":
-                html_parts.append(f'<input type="number" id="{field_id}" name="{field_id}" value="{current_value or 0}" class="{base_classes} max-w-2xl" />')
+                html_parts.append(
+                    f'<input type="number" id="{field_id}" name="{field_id}" '
+                    f'value="{current_value or 0}" class="{base_classes} max-w-2xl" />'
+                )
             else:  # string
                 escaped_value = str(current_value or "").replace('"', '&quot;')
-                html_parts.append(f'<input type="text" id="{field_id}" name="{field_id}" value="{escaped_value}" class="{base_classes} max-w-2xl" />')
-            
+                input_html = (
+                    f'<input type="text" id="{field_id}" name="{field_id}" '
+                    f'value="{escaped_value}" class="{base_classes} max-w-2xl" />'
+                )
+                html_parts.append(input_html)
+
             if help_text:
                 html_parts.append(f'<p class="text-xs text-base-500 mt-1">{help_text}</p>')
-            
+
             html_parts.append('</div>')
-        
+
         html_parts.append('</div>')
-        
+
         # Add JavaScript to collect values into hidden field on form submit
         html_parts.append('<script>')
         html_parts.append('(function() {')
@@ -284,25 +319,46 @@ class GameParametersWidget(forms.Widget):
             field_id = f"param_{param_name}"
             param_type = self.schema[param_name].get("type", "string")
             if param_type == "bool":
-                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
-                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = field_{param_name}.checked;')
+                html_parts.append("      var field_" + param_name + " = ")
+                html_parts.append('document.getElementById("' + field_id + '");')
+                html_parts.append(f'      if (field_{param_name}) {{')
+                html_parts.append(f'        params["{param_name}"] = field_{param_name}.checked;')
+                html_parts.append('      }')
             elif param_type == "int":
-                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
-                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = parseInt(field_{param_name}.value);')
+                html_parts.append('      var field_' + param_name + ' = ')
+                html_parts.append('document.getElementById("' + field_id + '");')
+                html_parts.append(
+                    '      if (field_' + param_name + ') ' +
+                    'params["' + param_name + '"] = parseInt(field_' + param_name + '.value);'
+                )
+                html_parts.append(f'      if (field_{param_name}) {{')
+                html_parts.append('        params["' + param_name + '"] = ')
+                html_parts.append('parseInt(field_' + param_name + '.value);')
+                html_parts.append('      }')
             else:
-                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
-                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = field_{param_name}.value;')
-        html_parts.append(f'      document.getElementById("id_{name}").value = JSON.stringify(params);')
+                html_parts.append("      var field_" + param_name + " = ")
+                html_parts.append('document.getElementById("' + field_id + '");')
+                html_parts.append('      if (field_' + param_name + ') {')
+                html_parts.append(f'      params["{param_name}"] = field_{param_name}.value;')
+                html_parts.append('      }')
+        html_parts.append('      var hidden_' + name + ' = ')
+        html_parts.append('document.getElementById("id_' + name + '");')
+        html_parts.append('      if (hidden_' + name + ') {')
+        html_parts.append('        hidden_' + name + '.value = JSON.stringify(params);')
+        html_parts.append('      }')
         html_parts.append('    });')
         html_parts.append('  }')
         html_parts.append('})();')
         html_parts.append('</script>')
-        
+
         return SafeString(''.join(html_parts))
-    
-    def value_from_datadict(self, data: dict[str, Any], files: dict[str, Any], name: str) -> Any:
+
+    def value_from_datadict(
+        self,
+        data: Mapping[str, Any],
+        files: Mapping[str, Any], name: str
+    ) -> Any:
         """Extract value from form submission"""
-        import json
         json_value = data.get(name, '{}')
         try:
             return json.loads(json_value) if json_value else {}
@@ -316,20 +372,21 @@ class GameForm(ModelForm[Game]):  # pylint: disable=unsubscriptable-object
     """
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        
+
         # Replace the games_parameters widget with our custom widget
         if self.instance and self.instance.game_processor:
-            from .models.game_processor import get_processor_parameters_schema, get_processor_default_parameters
-            schema = get_processor_parameters_schema(self.instance.game_processor)
-            defaults = get_processor_default_parameters(self.instance.game_processor)
-            
+            schema = game_processor.get_processor_parameters_schema(self.instance.game_processor)
+            defaults = game_processor.get_processor_default_parameters(self.instance.game_processor)
+
             if schema:
                 self.fields["games_parameters"].widget = GameParametersWidget(
                     schema=schema,
                     defaults=defaults
                 )
-                self.fields["games_parameters"].help_text = _("Configurez les paramètres du processeur de jeu")
-    
+                self.fields["games_parameters"].help_text = _(
+                    "Configurez les paramètres du processeur de jeu"
+                )
+
     def clean(self) -> None:
         # if players_per_team changed, reset associated seat_slots
         new_players_per_team = self.cleaned_data.get("players_per_team")
@@ -338,14 +395,13 @@ class GameForm(ModelForm[Game]):  # pylint: disable=unsubscriptable-object
             tournaments = BaseTournament.objects.filter(game=self.instance)
             seat_slots = SeatSlot.objects.filter(tournament__in=tournaments)
             seat_slots.delete()
-        
+
         # Initialize games_parameters with defaults if empty and processor is selected
         games_parameters = self.cleaned_data.get("games_parameters")
-        game_processor = self.cleaned_data.get("game_processor")
-        
-        if game_processor and (not games_parameters or games_parameters == {}):
-            from .models.game_processor import get_processor_default_parameters
-            defaults = get_processor_default_parameters(game_processor)
+        game_processor_cleaned = self.cleaned_data.get("game_processor")
+
+        if game_processor_cleaned and (not games_parameters or games_parameters == {}):
+            defaults = game_processor.get_processor_default_parameters(game_processor_cleaned)
             if defaults:
                 self.cleaned_data["games_parameters"] = defaults
 
@@ -364,7 +420,7 @@ class GameAdmin(ModelAdmin):  # type: ignore
     list_display = ("id", "name", "players_per_team", "validators", "game_processor")
     search_fields = ["name"]
     actions = ["reset_to_default_parameters"]
-    
+
     def get_fieldsets(self, request: HttpRequest, obj: Game | None = None
                      ) -> tuple[tuple[str, dict[str, Any]], ...]:
         """Return different fieldsets for add vs change views"""
@@ -372,47 +428,63 @@ class GameAdmin(ModelAdmin):  # type: ignore
             # Adding a new game - exclude games_parameters
             return (
                 (_("Informations générales"), {
-                    "fields": ("name", "short_name")
+                    "fields": ("name", "short_name"),
                 }),
                 (_("Configuration du jeu"), {
-                    "fields": ("players_per_team", "substitute_players_per_team", "team_per_match")
+                    "fields": (
+                        "players_per_team",
+                        "substitute_players_per_team",
+                        "team_per_match",
+                    ),
                 }),
                 (_("Validation et automatisation"), {
                     "fields": ("validators", "game_processor"),
-                    "description": _("Configurez la validation des pseudos et l'automatisation des matchs")
+                    "description": _(
+                        "Configurez la validation des pseudos et l'automatisation "
+                        "des matchs"
+                    ),
                 }),
             )
-        else:
-            # Editing existing game - include games_parameters
-            return (
-                (_("Informations générales"), {
-                    "fields": ("name", "short_name")
-                }),
-                (_("Configuration du jeu"), {
-                    "fields": ("players_per_team", "substitute_players_per_team", "team_per_match")
-                }),
-                (_("Validation et automatisation"), {
-                    "fields": ("validators", "game_processor", "games_parameters"),
-                    "description": _("Configurez la validation des pseudos et l'automatisation des matchs")
-                }),
-            )
-    
+        # Editing existing game - include games_parameters
+        return (
+            (_("Informations générales"), {
+                "fields": ("name", "short_name"),
+            }),
+            (_("Configuration du jeu"), {
+                "fields": (
+                    "players_per_team",
+                    "substitute_players_per_team",
+                    "team_per_match",
+                ),
+            }),
+            (_("Validation et automatisation"), {
+                "fields": (
+                    "validators",
+                    "game_processor",
+                    "games_parameters",
+                ),
+                "description": _(
+                    "Configurez la validation des pseudos et l'automatisation "
+                    "des matchs"
+                ),
+            }),
+        )
+
     def get_readonly_fields(self, request: HttpRequest, obj: Game | None = None
                            ) -> tuple[str, ...]:
         """Make games_parameters field show helpful information"""
         return tuple()
-    
+
     @admin.action(description=_("Réinitialiser aux paramètres par défaut"))
     def reset_to_default_parameters(self, request: HttpRequest, queryset: QuerySet[Game]) -> None:
         """Reset game parameters to processor defaults"""
-        from .models.game_processor import get_processor_default_parameters
-        
+
         for game in queryset:
-            defaults = get_processor_default_parameters(game.game_processor)
+            defaults = game_processor.get_processor_default_parameters(game.game_processor)
             if defaults:
                 game.games_parameters = defaults
                 game.save(update_fields=["games_parameters"])
-        
+
         self.message_user(
             request,
             _(f"{queryset.count()} jeu(x) réinitialisé(s) avec les paramètres par défaut.")
@@ -623,7 +695,7 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
         if obj is not None:
             return ('api_data',)
         return tuple()
-    
+
     def get_exclude(self, request: HttpRequest, obj: EventTournament | None = None
                    ) -> tuple[str, ...] | None:
         """Exclude api_data when creating a new tournament"""
@@ -651,16 +723,15 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
     def update_tournament_api(
         self, request: HttpRequest, queryset: QuerySet[EventTournament]
     ) -> None:
-        from django.core.exceptions import ValidationError
         success_count = 0
         error_messages = []
-        
+
         for tournament in queryset:
             processor_class = tournament.game.get_game_processor()
             if processor_class is None:
                 error_messages.append(f"{tournament.name}: Aucun processeur de jeu configuré")
                 continue
-            
+
             try:
                 api_data = processor_class.update_tournament(tournament)
                 if api_data is not None:
@@ -671,10 +742,10 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
                     error_messages.append(f"{tournament.name}: Échec de la mise à jour")
             except ValidationError as e:
                 error_messages.append(f"{tournament.name}: {e.message}")
-        
+
         if success_count > 0:
             self.message_user(request, _(f"{success_count} tournoi(s) mis à jour avec succès."))
-        
+
         if error_messages:
             for msg in error_messages:
                 self.message_user(request, msg, level='error')
@@ -1579,7 +1650,7 @@ class GroupMatchAdmin(ModelAdmin):  # type: ignore
         if obj is not None:
             return ('api_data',)
         return tuple()
-    
+
     def get_exclude(self, request: HttpRequest, obj: GroupMatch | None = None
                    ) -> tuple[str, ...] | None:
         """Exclude api_data when creating a new match"""
@@ -1739,7 +1810,7 @@ class KnockoutMatchAdmin(ModelAdmin):  # type: ignore
         if obj is not None:
             return ('api_data',)
         return tuple()
-    
+
     def get_exclude(self, request: HttpRequest, obj: KnockoutMatch | None = None
                    ) -> tuple[str, ...] | None:
         """Exclude api_data when creating a new match"""
@@ -1841,7 +1912,7 @@ class SwissMatchAdmin(ModelAdmin):  # type: ignore
         if obj is not None:
             return ('api_data',)
         return tuple()
-    
+
     def get_exclude(self, request: HttpRequest, obj: SwissMatch | None = None
                    ) -> tuple[str, ...] | None:
         """Exclude api_data when creating a new match"""

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -211,6 +211,9 @@ class GameParametersWidget(forms.Widget):
         self.schema = schema or {}
         self.defaults = defaults or {}
 
+    class Media:
+        js = ('js/game_parameters.js',)
+
     def render(self, name: str, value: Any, attrs: dict[str, Any] | None = None,
                renderer: BaseRenderer | None = None) -> SafeString:
         """Render individual form fields based on schema"""
@@ -228,7 +231,16 @@ class GameParametersWidget(forms.Widget):
 
         html_parts = []
         html_parts.append(f'<input type="hidden" name="{name}" id="id_{name}" value="" />')
-        html_parts.append('<div style="margin-top: 10px;">')
+
+        # Add data attributes for JavaScript
+        schema_json = json.dumps({
+            k: {'type': v.get('type', 'string')} for k, v in self.schema.items()
+        })
+        escaped_schema = schema_json.replace('"', '&quot;')
+        html_parts.append(
+            f'<div style="margin-top: 10px;" data-game-parameters '
+            f'data-field-name="{name}" data-schema="{escaped_schema}">'
+        )
 
         for param_name, param_info in self.schema.items():
             param_type = param_info.get("type", "string")
@@ -276,7 +288,6 @@ class GameParametersWidget(forms.Widget):
                 html_parts.append('</select>')
             elif param_type == "bool":
                 checked = 'checked' if current_value else ''
-                # Checkbox uses different styling
                 checkbox_classes = (
                     "rounded border-base-300 text-primary-600 shadow-sm "
                     "focus:border-primary-300 focus:ring focus:ring-offset-0 "
@@ -307,49 +318,6 @@ class GameParametersWidget(forms.Widget):
             html_parts.append('</div>')
 
         html_parts.append('</div>')
-
-        # Add JavaScript to collect values into hidden field on form submit
-        html_parts.append('<script>')
-        html_parts.append('(function() {')
-        html_parts.append(f'  var form = document.getElementById("id_{name}").closest("form");')
-        html_parts.append('  if (form) {')
-        html_parts.append('    form.addEventListener("submit", function() {')
-        html_parts.append('      var params = {};')
-        for param_name in self.schema.keys():
-            field_id = f"param_{param_name}"
-            param_type = self.schema[param_name].get("type", "string")
-            if param_type == "bool":
-                html_parts.append("      var field_" + param_name + " = ")
-                html_parts.append('document.getElementById("' + field_id + '");')
-                html_parts.append(f'      if (field_{param_name}) {{')
-                html_parts.append(f'        params["{param_name}"] = field_{param_name}.checked;')
-                html_parts.append('      }')
-            elif param_type == "int":
-                html_parts.append('      var field_' + param_name + ' = ')
-                html_parts.append('document.getElementById("' + field_id + '");')
-                html_parts.append(
-                    '      if (field_' + param_name + ') ' +
-                    'params["' + param_name + '"] = parseInt(field_' + param_name + '.value);'
-                )
-                html_parts.append(f'      if (field_{param_name}) {{')
-                html_parts.append('        params["' + param_name + '"] = ')
-                html_parts.append('parseInt(field_' + param_name + '.value);')
-                html_parts.append('      }')
-            else:
-                html_parts.append("      var field_" + param_name + " = ")
-                html_parts.append('document.getElementById("' + field_id + '");')
-                html_parts.append('      if (field_' + param_name + ') {')
-                html_parts.append(f'      params["{param_name}"] = field_{param_name}.value;')
-                html_parts.append('      }')
-        html_parts.append('      var hidden_' + name + ' = ')
-        html_parts.append('document.getElementById("id_' + name + '");')
-        html_parts.append('      if (hidden_' + name + ') {')
-        html_parts.append('        hidden_' + name + '.value = JSON.stringify(params);')
-        html_parts.append('      }')
-        html_parts.append('    });')
-        html_parts.append('  }')
-        html_parts.append('})();')
-        html_parts.append('</script>')
 
         return SafeString(''.join(html_parts))
 
@@ -1762,48 +1730,32 @@ class GroupMatchAdmin(ModelAdmin):  # type: ignore
     def api_data_display(self, obj: GroupMatch) -> SafeString:
         """Display api_data as collapsible JSON"""
         if not obj.api_data:
-            return SafeString('<p>Aucune donnée API</p>')
+            return SafeString('<p class="collapsible-json-empty">Aucune donnée API</p>')
 
         formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
         escaped_json = escape(formatted_json)
         widget_id = f"json_api_data_{obj.id}"
 
-        html_parts = [
-            '<div style="margin: 10px 0;">',
-            f'<button type="button" id="{widget_id}_toggle" ',
-            'style="background: #2563eb; color: white; padding: 8px 16px; ',
-            'border: none; border-radius: 4px; cursor: pointer; ',
-            'font-size: 14px; margin-bottom: 8px;">',
-            'Afficher / Masquer JSON',
-            '</button>',
-            f'<div id="{widget_id}_content" style="display: none; ',
-            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
-            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
-            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
-            'overflow-y: auto;">',
-            f'<pre style="margin: 0;">{escaped_json}</pre>',
-            '</div>',
-            '</div>',
-            '<script>',
-            '(function() {',
-            f'  var toggle = document.getElementById("{widget_id}_toggle");',
-            f'  var content = document.getElementById("{widget_id}_content");',
-            '  if (toggle && content) {',
-            '    toggle.addEventListener("click", function() {',
-            '      if (content.style.display === "none") {',
-            '        content.style.display = "block";',
-            '      } else {',
-            '        content.style.display = "none";',
-            '      }',
-            '    });',
-            '  }',
-            '})();',
-            '</script>',
-        ]
+        html = f'''
+        <div class="collapsible-json-container">
+            <button type="button" id="{widget_id}_toggle" class="collapsible-json-toggle">
+                Afficher JSON
+            </button>
+            <div id="{widget_id}_content" class="collapsible-json-content">
+                <pre>{escaped_json}</pre>
+            </div>
+        </div>
+        '''
 
-        return SafeString(''.join(html_parts))
+        return SafeString(html)
 
     api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
+
+    class Media:
+        css = {
+            'all': ('css/collapsible_json.css',)
+        }
+        js = ('js/collapsible_json.js',)
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_group_matchs_action(self, request: HttpRequest, queryset: QuerySet[GroupMatch]
@@ -1967,48 +1919,32 @@ class KnockoutMatchAdmin(ModelAdmin):  # type: ignore
     def api_data_display(self, obj: KnockoutMatch) -> SafeString:
         """Display api_data as collapsible JSON"""
         if not obj.api_data:
-            return SafeString('<p>Aucune donnée API</p>')
+            return SafeString('<p class="collapsible-json-empty">Aucune donnée API</p>')
 
         formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
         escaped_json = escape(formatted_json)
         widget_id = f"json_api_data_{obj.id}"
 
-        html_parts = [
-            '<div style="margin: 10px 0;">',
-            f'<button type="button" id="{widget_id}_toggle" ',
-            'style="background: #2563eb; color: white; padding: 8px 16px; ',
-            'border: none; border-radius: 4px; cursor: pointer; ',
-            'font-size: 14px; margin-bottom: 8px;">',
-            'Afficher / Masquer JSON',
-            '</button>',
-            f'<div id="{widget_id}_content" style="display: none; ',
-            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
-            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
-            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
-            'overflow-y: auto;">',
-            f'<pre style="margin: 0;">{escaped_json}</pre>',
-            '</div>',
-            '</div>',
-            '<script>',
-            '(function() {',
-            f'  var toggle = document.getElementById("{widget_id}_toggle");',
-            f'  var content = document.getElementById("{widget_id}_content");',
-            '  if (toggle && content) {',
-            '    toggle.addEventListener("click", function() {',
-            '      if (content.style.display === "none") {',
-            '        content.style.display = "block";',
-            '      } else {',
-            '        content.style.display = "none";',
-            '      }',
-            '    });',
-            '  }',
-            '})();',
-            '</script>',
-        ]
+        html = f'''
+        <div class="collapsible-json-container">
+            <button type="button" id="{widget_id}_toggle" class="collapsible-json-toggle">
+                Afficher JSON
+            </button>
+            <div id="{widget_id}_content" class="collapsible-json-content">
+                <pre>{escaped_json}</pre>
+            </div>
+        </div>
+        '''
 
-        return SafeString(''.join(html_parts))
+        return SafeString(html)
 
     api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
+
+    class Media:
+        css = {
+            'all': ('css/collapsible_json.css',)
+        }
+        js = ('js/collapsible_json.js',)
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_knockout_matchs_action(self, request: HttpRequest, queryset: QuerySet[KnockoutMatch]
@@ -2114,48 +2050,32 @@ class SwissMatchAdmin(ModelAdmin):  # type: ignore
     def api_data_display(self, obj: SwissMatch) -> SafeString:
         """Display api_data as collapsible JSON"""
         if not obj.api_data:
-            return SafeString('<p>Aucune donnée API</p>')
+            return SafeString('<p class="collapsible-json-empty">Aucune donnée API</p>')
 
         formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
         escaped_json = escape(formatted_json)
         widget_id = f"json_api_data_{obj.id}"
 
-        html_parts = [
-            '<div style="margin: 10px 0;">',
-            f'<button type="button" id="{widget_id}_toggle" ',
-            'style="background: #2563eb; color: white; padding: 8px 16px; ',
-            'border: none; border-radius: 4px; cursor: pointer; ',
-            'font-size: 14px; margin-bottom: 8px;">',
-            'Afficher / Masquer JSON',
-            '</button>',
-            f'<div id="{widget_id}_content" style="display: none; ',
-            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
-            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
-            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
-            'overflow-y: auto;">',
-            f'<pre style="margin: 0;">{escaped_json}</pre>',
-            '</div>',
-            '</div>',
-            '<script>',
-            '(function() {',
-            f'  var toggle = document.getElementById("{widget_id}_toggle");',
-            f'  var content = document.getElementById("{widget_id}_content");',
-            '  if (toggle && content) {',
-            '    toggle.addEventListener("click", function() {',
-            '      if (content.style.display === "none") {',
-            '        content.style.display = "block";',
-            '      } else {',
-            '        content.style.display = "none";',
-            '      }',
-            '    });',
-            '  }',
-            '})();',
-            '</script>',
-        ]
+        html = f'''
+        <div class="collapsible-json-container">
+            <button type="button" id="{widget_id}_toggle" class="collapsible-json-toggle">
+                Afficher JSON
+            </button>
+            <div id="{widget_id}_content" class="collapsible-json-content">
+                <pre>{escaped_json}</pre>
+            </div>
+        </div>
+        '''
 
-        return SafeString(''.join(html_parts))
+        return SafeString(html)
 
     api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
+
+    class Media:
+        css = {
+            'all': ('css/collapsible_json.css',)
+        }
+        js = ('js/collapsible_json.js',)
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_swiss_matchs_action(self, request: HttpRequest, queryset: QuerySet[SwissMatch]

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -810,7 +810,7 @@ class PrivateTournamentAdmin(ModelAdmin[PrivateTournament]): # type: ignore
     list_display = ("id", "name", "game", "get_occupancy")
     search_fields = ["name", "game__name"]
 
-    actions = ['update_name']
+    actions = ['update_name', 'update_tournament_api']
 
     def get_occupancy(self, obj: PrivateTournament) -> str:
         """
@@ -821,15 +821,60 @@ class PrivateTournamentAdmin(ModelAdmin[PrivateTournament]): # type: ignore
             validated=True,
         ).count()) + " / " + str(obj.get_max_team())
 
+    get_occupancy.short_description = 'Remplissage'  # type: ignore[attr-defined]
+
+    def get_readonly_fields(self, request: HttpRequest, obj: PrivateTournament | None = None
+                           ) -> tuple[str, ...]:
+        """Make api_data readonly when editing"""
+        if obj is not None:
+            return ('api_data',)
+        return tuple()
+
+    def get_exclude(self, request: HttpRequest, obj: PrivateTournament | None = None
+                   ) -> tuple[str, ...] | None:
+        """Exclude api_data when creating a new tournament"""
+        if obj is None:
+            return ('api_data',)
+        return None
+
     @admin.action(description=_("Mettre à jour les pseudos"))
     def update_name(
-        self, request: HttpRequest, queryset: QuerySet[EventTournament]
+        self, request: HttpRequest, queryset: QuerySet[PrivateTournament]
     ) -> None:
         for tournament in queryset:
             tournament.update_name_in_game()
         self.message_user(request,_("Les pseudo ont été mis à jour."))
 
-    get_occupancy.short_description = 'Remplissage'  # type: ignore[attr-defined]
+    @admin.action(description=_("Rafraîchir les données API du tournoi"))
+    def update_tournament_api(
+        self, request: HttpRequest, queryset: QuerySet[PrivateTournament]
+    ) -> None:
+        success_count = 0
+        error_messages = []
+
+        for tournament in queryset:
+            processor_class = tournament.game.get_game_processor()
+            if processor_class is None:
+                error_messages.append(f"{tournament.name}: Aucun processeur de jeu configuré")
+                continue
+
+            try:
+                api_data = processor_class.update_tournament(tournament)
+                if api_data is not None:
+                    tournament.api_data = api_data
+                    tournament.save(update_fields=['api_data'])
+                    success_count += 1
+                else:
+                    error_messages.append(f"{tournament.name}: Échec de la mise à jour")
+            except ValidationError as e:
+                error_messages.append(f"{tournament.name}: {e.message}")
+
+        if success_count > 0:
+            self.message_user(request, _(f"{success_count} tournoi(s) mis à jour avec succès."))
+
+        if error_messages:
+            for msg in error_messages:
+                self.message_user(request, msg, level='error')
 
 
 admin.site.register(PrivateTournament, PrivateTournamentAdmin)

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -23,8 +23,8 @@ from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, resolve, reverse, URLPattern
 from django.utils.decorators import method_decorator
-from django.utils.html import escape
-from django.utils.safestring import SafeString
+from django.utils.html import escape, format_html
+from django.utils.safestring import SafeString, mark_safe
 from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters
 from django.db.models import Q
@@ -200,10 +200,136 @@ class EventAdmin(ModelAdmin):  # type: ignore
 admin.site.register(Event, EventAdmin)
 
 
+class GameParametersWidget(forms.Widget):
+    """Custom widget that renders individual fields for game parameters"""
+    template_name = ""  # Empty string instead of None for unfold compatibility
+    
+    def __init__(self, schema: dict[str, Any] | None = None, 
+                 defaults: dict[str, Any] | None = None, attrs: dict[str, Any] | None = None):
+        super().__init__(attrs)
+        self.schema = schema or {}
+        self.defaults = defaults or {}
+    
+    def render(self, name: str, value: Any, attrs: dict[str, Any] | None = None,
+               renderer: BaseRenderer | None = None) -> SafeString:
+        """Render individual form fields based on schema"""
+        if not self.schema:
+            return SafeString(f'<input type="hidden" name="{name}" value="{{}}" />')
+        
+        # Parse current value
+        if isinstance(value, str):
+            import json
+            try:
+                current_values = json.loads(value) if value else {}
+            except (json.JSONDecodeError, TypeError):
+                current_values = {}
+        else:
+            current_values = value or {}
+        
+        html_parts = []
+        html_parts.append(f'<input type="hidden" name="{name}" id="id_{name}" value="" />')
+        html_parts.append('<div style="margin-top: 10px;">')
+        
+        for param_name, param_info in self.schema.items():
+            param_type = param_info.get("type", "string")
+            label = param_info.get("label", param_name)
+            help_text = param_info.get("help_text", "")
+            field_id = f"param_{param_name}"
+            
+            # Get current or default value
+            current_value = current_values.get(param_name)
+            if current_value is None and param_name in self.defaults:
+                current_value = self.defaults[param_name]
+            
+            # Render field
+            html_parts.append('<div style="margin-bottom: 20px;">')
+            html_parts.append(f'<label for="{field_id}" class="block text-sm font-medium mb-2">{label}</label>')
+            
+            # Common classes for all input fields
+            base_classes = "border border-base-200 bg-white font-medium placeholder-base-400 rounded shadow-sm text-font-default-light text-sm focus:ring focus:ring-primary-300 focus:border-primary-600 focus:outline-none dark:bg-base-900 dark:border-base-700 dark:text-font-default-dark dark:focus:border-primary-600 dark:focus:ring-primary-700 dark:focus:ring-opacity-50 px-3 py-2 w-full"
+            
+            if param_type == "choice":
+                choices = param_info.get("choices", [])
+                html_parts.append(f'<select id="{field_id}" name="{field_id}" class="{base_classes} pr-8 max-w-2xl appearance-none">')
+                for choice_value, choice_label in choices:
+                    selected = 'selected' if str(current_value) == str(choice_value) else ''
+                    html_parts.append(f'<option value="{choice_value}" {selected}>{choice_label}</option>')
+                html_parts.append('</select>')
+            elif param_type == "bool":
+                checked = 'checked' if current_value else ''
+                # Checkbox uses different styling
+                checkbox_classes = "rounded border-base-300 text-primary-600 shadow-sm focus:border-primary-300 focus:ring focus:ring-offset-0 focus:ring-primary-200 focus:ring-opacity-50 dark:bg-base-900 dark:border-base-600 dark:checked:bg-primary-600 dark:checked:border-primary-600 dark:focus:ring-offset-base-800"
+                html_parts.append(f'<input type="checkbox" id="{field_id}" name="{field_id}" {checked} class="{checkbox_classes}" />')
+            elif param_type == "int":
+                html_parts.append(f'<input type="number" id="{field_id}" name="{field_id}" value="{current_value or 0}" class="{base_classes} max-w-2xl" />')
+            else:  # string
+                escaped_value = str(current_value or "").replace('"', '&quot;')
+                html_parts.append(f'<input type="text" id="{field_id}" name="{field_id}" value="{escaped_value}" class="{base_classes} max-w-2xl" />')
+            
+            if help_text:
+                html_parts.append(f'<p class="text-xs text-base-500 mt-1">{help_text}</p>')
+            
+            html_parts.append('</div>')
+        
+        html_parts.append('</div>')
+        
+        # Add JavaScript to collect values into hidden field on form submit
+        html_parts.append('<script>')
+        html_parts.append('(function() {')
+        html_parts.append(f'  var form = document.getElementById("id_{name}").closest("form");')
+        html_parts.append('  if (form) {')
+        html_parts.append('    form.addEventListener("submit", function() {')
+        html_parts.append('      var params = {};')
+        for param_name in self.schema.keys():
+            field_id = f"param_{param_name}"
+            param_type = self.schema[param_name].get("type", "string")
+            if param_type == "bool":
+                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
+                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = field_{param_name}.checked;')
+            elif param_type == "int":
+                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
+                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = parseInt(field_{param_name}.value);')
+            else:
+                html_parts.append(f'      var field_{param_name} = document.getElementById("{field_id}");')
+                html_parts.append(f'      if (field_{param_name}) params["{param_name}"] = field_{param_name}.value;')
+        html_parts.append(f'      document.getElementById("id_{name}").value = JSON.stringify(params);')
+        html_parts.append('    });')
+        html_parts.append('  }')
+        html_parts.append('})();')
+        html_parts.append('</script>')
+        
+        return SafeString(''.join(html_parts))
+    
+    def value_from_datadict(self, data: dict[str, Any], files: dict[str, Any], name: str) -> Any:
+        """Extract value from form submission"""
+        import json
+        json_value = data.get(name, '{}')
+        try:
+            return json.loads(json_value) if json_value else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+
 class GameForm(ModelForm[Game]):  # pylint: disable=unsubscriptable-object
     """
     Custom form for the Game model
     """
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        
+        # Replace the games_parameters widget with our custom widget
+        if self.instance and self.instance.game_processor:
+            from .models.game_processor import get_processor_parameters_schema, get_processor_default_parameters
+            schema = get_processor_parameters_schema(self.instance.game_processor)
+            defaults = get_processor_default_parameters(self.instance.game_processor)
+            
+            if schema:
+                self.fields["games_parameters"].widget = GameParametersWidget(
+                    schema=schema,
+                    defaults=defaults
+                )
+                self.fields["games_parameters"].help_text = _("Configurez les paramètres du processeur de jeu")
+    
     def clean(self) -> None:
         # if players_per_team changed, reset associated seat_slots
         new_players_per_team = self.cleaned_data.get("players_per_team")
@@ -212,6 +338,16 @@ class GameForm(ModelForm[Game]):  # pylint: disable=unsubscriptable-object
             tournaments = BaseTournament.objects.filter(game=self.instance)
             seat_slots = SeatSlot.objects.filter(tournament__in=tournaments)
             seat_slots.delete()
+        
+        # Initialize games_parameters with defaults if empty and processor is selected
+        games_parameters = self.cleaned_data.get("games_parameters")
+        game_processor = self.cleaned_data.get("game_processor")
+        
+        if game_processor and (not games_parameters or games_parameters == {}):
+            from .models.game_processor import get_processor_default_parameters
+            defaults = get_processor_default_parameters(game_processor)
+            if defaults:
+                self.cleaned_data["games_parameters"] = defaults
 
     class Meta:
         """
@@ -225,8 +361,62 @@ class GameAdmin(ModelAdmin):  # type: ignore
     """Admin handler for Games"""
     form = GameForm
 
-    list_display = ("id", "name", "players_per_team")
+    list_display = ("id", "name", "players_per_team", "validators", "game_processor")
     search_fields = ["name"]
+    actions = ["reset_to_default_parameters"]
+    
+    def get_fieldsets(self, request: HttpRequest, obj: Game | None = None
+                     ) -> tuple[tuple[str, dict[str, Any]], ...]:
+        """Return different fieldsets for add vs change views"""
+        if obj is None:
+            # Adding a new game - exclude games_parameters
+            return (
+                (_("Informations générales"), {
+                    "fields": ("name", "short_name")
+                }),
+                (_("Configuration du jeu"), {
+                    "fields": ("players_per_team", "substitute_players_per_team", "team_per_match")
+                }),
+                (_("Validation et automatisation"), {
+                    "fields": ("validators", "game_processor"),
+                    "description": _("Configurez la validation des pseudos et l'automatisation des matchs")
+                }),
+            )
+        else:
+            # Editing existing game - include games_parameters
+            return (
+                (_("Informations générales"), {
+                    "fields": ("name", "short_name")
+                }),
+                (_("Configuration du jeu"), {
+                    "fields": ("players_per_team", "substitute_players_per_team", "team_per_match")
+                }),
+                (_("Validation et automatisation"), {
+                    "fields": ("validators", "game_processor", "games_parameters"),
+                    "description": _("Configurez la validation des pseudos et l'automatisation des matchs")
+                }),
+            )
+    
+    def get_readonly_fields(self, request: HttpRequest, obj: Game | None = None
+                           ) -> tuple[str, ...]:
+        """Make games_parameters field show helpful information"""
+        return tuple()
+    
+    @admin.action(description=_("Réinitialiser aux paramètres par défaut"))
+    def reset_to_default_parameters(self, request: HttpRequest, queryset: QuerySet[Game]) -> None:
+        """Reset game parameters to processor defaults"""
+        from .models.game_processor import get_processor_default_parameters
+        
+        for game in queryset:
+            defaults = get_processor_default_parameters(game.game_processor)
+            if defaults:
+                game.games_parameters = defaults
+                game.save(update_fields=["games_parameters"])
+        
+        self.message_user(
+            request,
+            _(f"{queryset.count()} jeu(x) réinitialisé(s) avec les paramètres par défaut.")
+        )
 
 
 admin.site.register(Game, GameAdmin)
@@ -402,7 +592,7 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
 
     list_filter = (EventTournamentFilter, GameTournamentFilter)
 
-    actions = ['update_name', 'expand_threshold']
+    actions = ['update_name', 'expand_threshold', 'update_tournament_api']
 
     def get_form(
         self,
@@ -427,6 +617,20 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
 
     get_occupancy.short_description = 'Remplissage'  # type: ignore[attr-defined]
 
+    def get_readonly_fields(self, request: HttpRequest, obj: EventTournament | None = None
+                           ) -> tuple[str, ...]:
+        """Make api_data readonly when editing"""
+        if obj is not None:
+            return ('api_data',)
+        return tuple()
+    
+    def get_exclude(self, request: HttpRequest, obj: EventTournament | None = None
+                   ) -> tuple[str, ...] | None:
+        """Exclude api_data when creating a new tournament"""
+        if obj is None:
+            return ('api_data',)
+        return None
+
     @admin.action(description=_("Mettre à jour les pseudos"))
     def update_name(
         self, request: HttpRequest, queryset: QuerySet[EventTournament]
@@ -442,6 +646,38 @@ class EventTournamentAdmin(ModelAdmin[EventTournament]): # type: ignore
         for tournament in queryset:
             tournament.try_expand_threshold()
         self.message_user(request,_("Le seuil a été mis à jour."))
+
+    @admin.action(description=_("Rafraîchir les données API du tournoi"))
+    def update_tournament_api(
+        self, request: HttpRequest, queryset: QuerySet[EventTournament]
+    ) -> None:
+        from django.core.exceptions import ValidationError
+        success_count = 0
+        error_messages = []
+        
+        for tournament in queryset:
+            processor_class = tournament.game.get_game_processor()
+            if processor_class is None:
+                error_messages.append(f"{tournament.name}: Aucun processeur de jeu configuré")
+                continue
+            
+            try:
+                api_data = processor_class.update_tournament(tournament)
+                if api_data is not None:
+                    tournament.api_data = api_data
+                    tournament.save(update_fields=['api_data'])
+                    success_count += 1
+                else:
+                    error_messages.append(f"{tournament.name}: Échec de la mise à jour")
+            except ValidationError as e:
+                error_messages.append(f"{tournament.name}: {e.message}")
+        
+        if success_count > 0:
+            self.message_user(request, _(f"{success_count} tournoi(s) mis à jour avec succès."))
+        
+        if error_messages:
+            for msg in error_messages:
+                self.message_user(request, msg, level='error')
 
     class Media:
         css = {
@@ -1337,6 +1573,20 @@ class GroupMatchAdmin(ModelAdmin):  # type: ignore
 
     list_filter = ["group__tournament", "group", RoundNumberFilter, "index_in_round", "status"]
 
+    def get_readonly_fields(self, request: HttpRequest, obj: GroupMatch | None = None
+                           ) -> tuple[str, ...]:
+        """Make api_data readonly when editing"""
+        if obj is not None:
+            return ('api_data',)
+        return tuple()
+    
+    def get_exclude(self, request: HttpRequest, obj: GroupMatch | None = None
+                   ) -> tuple[str, ...] | None:
+        """Exclude api_data when creating a new match"""
+        if obj is None:
+            return ('api_data',)
+        return None
+
     @admin.action(description=_("Lancer les matchs"))
     def launch_group_matchs_action(self, request: HttpRequest, queryset: QuerySet[GroupMatch]
                                    ) -> None:
@@ -1483,6 +1733,20 @@ class KnockoutMatchAdmin(ModelAdmin):  # type: ignore
     list_filter = ["bracket__tournament", "bracket", "bracket_set", BracketMatchFilter,
                    "index_in_round", "status"]
 
+    def get_readonly_fields(self, request: HttpRequest, obj: KnockoutMatch | None = None
+                           ) -> tuple[str, ...]:
+        """Make api_data readonly when editing"""
+        if obj is not None:
+            return ('api_data',)
+        return tuple()
+    
+    def get_exclude(self, request: HttpRequest, obj: KnockoutMatch | None = None
+                   ) -> tuple[str, ...] | None:
+        """Exclude api_data when creating a new match"""
+        if obj is None:
+            return ('api_data',)
+        return None
+
     @admin.action(description=_("Lancer les matchs"))
     def launch_knockout_matchs_action(self, request: HttpRequest, queryset: QuerySet[KnockoutMatch]
                                       ) -> None:
@@ -1570,6 +1834,20 @@ class SwissMatchAdmin(ModelAdmin):  # type: ignore
     ]
 
     list_filter = ["swiss__tournament", "swiss", RoundNumberFilter, "index_in_round", "status"]
+
+    def get_readonly_fields(self, request: HttpRequest, obj: SwissMatch | None = None
+                           ) -> tuple[str, ...]:
+        """Make api_data readonly when editing"""
+        if obj is not None:
+            return ('api_data',)
+        return tuple()
+    
+    def get_exclude(self, request: HttpRequest, obj: SwissMatch | None = None
+                   ) -> tuple[str, ...] | None:
+        """Exclude api_data when creating a new match"""
+        if obj is None:
+            return ('api_data',)
+        return None
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_swiss_matchs_action(self, request: HttpRequest, queryset: QuerySet[SwissMatch]

--- a/insalan/tournament/admin.py
+++ b/insalan/tournament/admin.py
@@ -366,6 +366,78 @@ class GameParametersWidget(forms.Widget):
             return {}
 
 
+class CollapsibleJSONWidget(forms.Widget):
+    """Custom widget that renders JSON data in a collapsible, formatted view"""
+    template_name = ""  # Empty string for unfold compatibility
+
+    def render(self, name: str, value: Any, attrs: dict[str, Any] | None = None,
+               renderer: BaseRenderer | None = None) -> SafeString:
+        """Render JSON data as formatted, collapsible HTML"""
+        if value is None or value == '':
+            value = {}
+
+        # Parse JSON if it's a string
+        if isinstance(value, str):
+            try:
+                json_data = json.loads(value) if value else {}
+            except (json.JSONDecodeError, TypeError):
+                json_data = {}
+        else:
+            json_data = value or {}
+
+        # Format JSON with indentation
+        formatted_json = json.dumps(json_data, indent=2, ensure_ascii=False)
+        escaped_json = escape(formatted_json)
+
+        # Generate unique ID for this widget instance
+        widget_id = f"json_{name}_{id(self)}"
+
+        html_parts = []
+
+        # Hidden input to store the actual data
+        html_parts.append(f'<input type="hidden" name="{name}" value=\'{formatted_json}\' />')
+
+        # Collapsible container
+        html_parts.append('<div style="margin: 10px 0;">')
+        html_parts.append(
+            f'<button type="button" id="{widget_id}_toggle" '
+            f'style="background: #2563eb; color: white; padding: 8px 16px; '
+            f'border: none; border-radius: 4px; cursor: pointer; '
+            f'font-size: 14px; margin-bottom: 8px;">'
+            f'Afficher / Masquer JSON'
+            f'</button>'
+        )
+
+        # JSON display area (initially hidden)
+        html_parts.append(
+            f'<div id="{widget_id}_content" style="display: none; '
+            f'background: #1e293b; color: #e2e8f0; padding: 16px; '
+            f'border-radius: 4px; overflow-x: auto; font-family: monospace; '
+            f'font-size: 13px; line-height: 1.6; max-height: 500px; '
+            f'overflow-y: auto;">'
+        )
+        html_parts.append(f'<pre style="margin: 0;">{escaped_json}</pre>')
+        html_parts.append('</div>')
+        html_parts.append('</div>')
+
+        # JavaScript for toggle functionality
+        html_parts.append('<script>')
+        html_parts.append('(function() {')
+        html_parts.append(f'  var toggle = document.getElementById("{widget_id}_toggle");')
+        html_parts.append(f'  var content = document.getElementById("{widget_id}_content");')
+        html_parts.append('  toggle.addEventListener("click", function() {')
+        html_parts.append('    if (content.style.display === "none") {')
+        html_parts.append('      content.style.display = "block";')
+        html_parts.append('    } else {')
+        html_parts.append('      content.style.display = "none";')
+        html_parts.append('    }')
+        html_parts.append('  });')
+        html_parts.append('})();')
+        html_parts.append('</script>')
+
+        return SafeString(''.join(html_parts))
+
+
 class GameForm(ModelForm[Game]):  # pylint: disable=unsubscriptable-object
     """
     Custom form for the Game model
@@ -1630,9 +1702,40 @@ class GroupAdmin(ModelAdmin):  # type: ignore
 admin.site.register(Group, GroupAdmin)
 
 
+class GroupMatchForm(ModelForm[GroupMatch]):  # pylint: disable=unsubscriptable-object
+    """Custom form for GroupMatch with collapsible JSON widget for api_data"""
+
+    class Meta:
+        model = GroupMatch
+        fields = '__all__'
+        widgets = {
+            'api_data': CollapsibleJSONWidget(),
+        }
+
+
+class KnockoutMatchForm(ModelForm[KnockoutMatch]):  # pylint: disable=unsubscriptable-object
+    """Custom form for KnockoutMatch with collapsible JSON widget for api_data"""
+
+    class Meta:
+        model = KnockoutMatch
+        fields = '__all__'
+        widgets = {
+            'api_data': CollapsibleJSONWidget(),
+        }
+
+
+class SwissMatchForm(ModelForm[SwissMatch]):  # pylint: disable=unsubscriptable-object
+    """Custom form for SwissMatch with collapsible JSON widget for api_data"""
+
+    class Meta:
+        model = SwissMatch
+        fields = '__all__'
+
+
 class GroupMatchAdmin(ModelAdmin):  # type: ignore
     """Admin handle for group matchs"""
 
+    form = GroupMatchForm
     list_display = ("id", "group", "status", "round_number", "index_in_round", "bo_type", )
     search_fields = ["index_in_round", "round_number"]
     # filter_horizontal = ("teams",)
@@ -1646,17 +1749,61 @@ class GroupMatchAdmin(ModelAdmin):  # type: ignore
 
     def get_readonly_fields(self, request: HttpRequest, obj: GroupMatch | None = None
                            ) -> tuple[str, ...]:
-        """Make api_data readonly when editing"""
+        """Make api_data_display readonly when editing"""
         if obj is not None:
-            return ('api_data',)
+            return ('api_data_display',)
         return tuple()
 
     def get_exclude(self, request: HttpRequest, obj: GroupMatch | None = None
                    ) -> tuple[str, ...] | None:
-        """Exclude api_data when creating a new match"""
-        if obj is None:
-            return ('api_data',)
-        return None
+        """Exclude api_data field (we show api_data_display instead)"""
+        return ('api_data',)
+
+    def api_data_display(self, obj: GroupMatch) -> SafeString:
+        """Display api_data as collapsible JSON"""
+        if not obj.api_data:
+            return SafeString('<p>Aucune donnée API</p>')
+
+        formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
+        escaped_json = escape(formatted_json)
+        widget_id = f"json_api_data_{obj.id}"
+
+        html_parts = [
+            '<div style="margin: 10px 0;">',
+            f'<button type="button" id="{widget_id}_toggle" ',
+            'style="background: #2563eb; color: white; padding: 8px 16px; ',
+            'border: none; border-radius: 4px; cursor: pointer; ',
+            'font-size: 14px; margin-bottom: 8px;">',
+            'Afficher / Masquer JSON',
+            '</button>',
+            f'<div id="{widget_id}_content" style="display: none; ',
+            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
+            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
+            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
+            'overflow-y: auto;">',
+            f'<pre style="margin: 0;">{escaped_json}</pre>',
+            '</div>',
+            '</div>',
+            '<script>',
+            '(function() {',
+            f'  var toggle = document.getElementById("{widget_id}_toggle");',
+            f'  var content = document.getElementById("{widget_id}_content");',
+            '  if (toggle && content) {',
+            '    toggle.addEventListener("click", function() {',
+            '      if (content.style.display === "none") {',
+            '        content.style.display = "block";',
+            '      } else {',
+            '        content.style.display = "none";',
+            '      }',
+            '    });',
+            '  }',
+            '})();',
+            '</script>',
+        ]
+
+        return SafeString(''.join(html_parts))
+
+    api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_group_matchs_action(self, request: HttpRequest, queryset: QuerySet[GroupMatch]
@@ -1793,6 +1940,7 @@ admin.site.register(Bracket, BracketAdmin)
 class KnockoutMatchAdmin(ModelAdmin):  # type: ignore
     """Admin handle for Knockout matchs"""
 
+    form = KnockoutMatchForm
     list_display = ("id", "bracket", "status", "bracket_set", "round_number", "index_in_round",
                     "bo_type")
     inlines = [ScoreInline]
@@ -1806,17 +1954,61 @@ class KnockoutMatchAdmin(ModelAdmin):  # type: ignore
 
     def get_readonly_fields(self, request: HttpRequest, obj: KnockoutMatch | None = None
                            ) -> tuple[str, ...]:
-        """Make api_data readonly when editing"""
+        """Make api_data_display readonly when editing"""
         if obj is not None:
-            return ('api_data',)
+            return ('api_data_display',)
         return tuple()
 
     def get_exclude(self, request: HttpRequest, obj: KnockoutMatch | None = None
                    ) -> tuple[str, ...] | None:
-        """Exclude api_data when creating a new match"""
-        if obj is None:
-            return ('api_data',)
-        return None
+        """Exclude api_data field (we show api_data_display instead)"""
+        return ('api_data',)
+
+    def api_data_display(self, obj: KnockoutMatch) -> SafeString:
+        """Display api_data as collapsible JSON"""
+        if not obj.api_data:
+            return SafeString('<p>Aucune donnée API</p>')
+
+        formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
+        escaped_json = escape(formatted_json)
+        widget_id = f"json_api_data_{obj.id}"
+
+        html_parts = [
+            '<div style="margin: 10px 0;">',
+            f'<button type="button" id="{widget_id}_toggle" ',
+            'style="background: #2563eb; color: white; padding: 8px 16px; ',
+            'border: none; border-radius: 4px; cursor: pointer; ',
+            'font-size: 14px; margin-bottom: 8px;">',
+            'Afficher / Masquer JSON',
+            '</button>',
+            f'<div id="{widget_id}_content" style="display: none; ',
+            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
+            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
+            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
+            'overflow-y: auto;">',
+            f'<pre style="margin: 0;">{escaped_json}</pre>',
+            '</div>',
+            '</div>',
+            '<script>',
+            '(function() {',
+            f'  var toggle = document.getElementById("{widget_id}_toggle");',
+            f'  var content = document.getElementById("{widget_id}_content");',
+            '  if (toggle && content) {',
+            '    toggle.addEventListener("click", function() {',
+            '      if (content.style.display === "none") {',
+            '        content.style.display = "block";',
+            '      } else {',
+            '        content.style.display = "none";',
+            '      }',
+            '    });',
+            '  }',
+            '})();',
+            '</script>',
+        ]
+
+        return SafeString(''.join(html_parts))
+
+    api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_knockout_matchs_action(self, request: HttpRequest, queryset: QuerySet[KnockoutMatch]
@@ -1896,6 +2088,7 @@ admin.site.register(SwissRound, SwissRoundAdmin)
 class SwissMatchAdmin(ModelAdmin):  # type: ignore
     """Admin handle for Swiss matchs"""
 
+    form = SwissMatchForm
     list_display = ("id", "swiss", "status", "round_number", "index_in_round", "bo_type",
                     "score_group")
     inlines = [ScoreInline]
@@ -1908,17 +2101,61 @@ class SwissMatchAdmin(ModelAdmin):  # type: ignore
 
     def get_readonly_fields(self, request: HttpRequest, obj: SwissMatch | None = None
                            ) -> tuple[str, ...]:
-        """Make api_data readonly when editing"""
+        """Make api_data_display readonly when editing"""
         if obj is not None:
-            return ('api_data',)
+            return ('api_data_display',)
         return tuple()
 
     def get_exclude(self, request: HttpRequest, obj: SwissMatch | None = None
                    ) -> tuple[str, ...] | None:
-        """Exclude api_data when creating a new match"""
-        if obj is None:
-            return ('api_data',)
-        return None
+        """Exclude api_data field (we show api_data_display instead)"""
+        return ('api_data',)
+
+    def api_data_display(self, obj: SwissMatch) -> SafeString:
+        """Display api_data as collapsible JSON"""
+        if not obj.api_data:
+            return SafeString('<p>Aucune donnée API</p>')
+
+        formatted_json = json.dumps(obj.api_data, indent=2, ensure_ascii=False)
+        escaped_json = escape(formatted_json)
+        widget_id = f"json_api_data_{obj.id}"
+
+        html_parts = [
+            '<div style="margin: 10px 0;">',
+            f'<button type="button" id="{widget_id}_toggle" ',
+            'style="background: #2563eb; color: white; padding: 8px 16px; ',
+            'border: none; border-radius: 4px; cursor: pointer; ',
+            'font-size: 14px; margin-bottom: 8px;">',
+            'Afficher / Masquer JSON',
+            '</button>',
+            f'<div id="{widget_id}_content" style="display: none; ',
+            'background: #1e293b; color: #e2e8f0; padding: 16px; ',
+            'border-radius: 4px; overflow-x: auto; font-family: monospace; ',
+            'font-size: 13px; line-height: 1.6; max-height: 500px; ',
+            'overflow-y: auto;">',
+            f'<pre style="margin: 0;">{escaped_json}</pre>',
+            '</div>',
+            '</div>',
+            '<script>',
+            '(function() {',
+            f'  var toggle = document.getElementById("{widget_id}_toggle");',
+            f'  var content = document.getElementById("{widget_id}_content");',
+            '  if (toggle && content) {',
+            '    toggle.addEventListener("click", function() {',
+            '      if (content.style.display === "none") {',
+            '        content.style.display = "block";',
+            '      } else {',
+            '        content.style.display = "none";',
+            '      }',
+            '    });',
+            '  }',
+            '})();',
+            '</script>',
+        ]
+
+        return SafeString(''.join(html_parts))
+
+    api_data_display.short_description = 'Données API'  # type: ignore[attr-defined]
 
     @admin.action(description=_("Lancer les matchs"))
     def launch_swiss_matchs_action(self, request: HttpRequest, queryset: QuerySet[SwissMatch]

--- a/insalan/tournament/manage/bracket.py
+++ b/insalan/tournament/manage/bracket.py
@@ -22,7 +22,7 @@ def create_empty_knockout_matchs(bracket: Bracket, bo_type: BestofType = BestofT
         for match_id in range(1,match_count+1):
             match = KnockoutMatch.objects.create(round_number=round_idx, index_in_round=match_id,
                                          bracket=bracket, bo_type=bo_type)
-            
+
             # Call game processor for match creation
             if processor_class is not None:
                 api_data = processor_class.create_match(match)
@@ -44,21 +44,21 @@ def create_empty_knockout_matchs(bracket: Bracket, bo_type: BestofType = BestofT
                     bracket_set=BracketSet.LOOSER,
                     bo_type=bo_type,
                 )
-                
+
                 # Call game processor for match creation
                 if processor_class is not None:
                     api_data = processor_class.create_match(match)
                     if api_data is not None:
                         match.api_data = api_data
                         match.save(update_fields=['api_data'])
-        
+
         match = KnockoutMatch.objects.create(
             round_number=0,
             index_in_round=1,
             bracket=bracket,
             bo_type=bo_type,
         )
-        
+
         # Call game processor for match creation
         if processor_class is not None:
             api_data = processor_class.create_match(match)

--- a/insalan/tournament/manage/bracket.py
+++ b/insalan/tournament/manage/bracket.py
@@ -5,7 +5,14 @@ def create_empty_knockout_matchs(bracket: Bracket, bo_type: BestofType = BestofT
     depth = bracket.get_depth()
 
     for match in KnockoutMatch.objects.filter(bracket=bracket):
+        # Call game processor for match deletion
+        processor_class = bracket.tournament.game.get_game_processor()
+        if processor_class is not None:
+            processor_class.delete_match(match)
         match.delete()
+
+    # Get game processor for match creation
+    processor_class = bracket.tournament.game.get_game_processor()
 
     for round_idx in range(1,depth+1):
         match_count = min(
@@ -13,8 +20,15 @@ def create_empty_knockout_matchs(bracket: Bracket, bo_type: BestofType = BestofT
             ceil(bracket.get_max_match_count()/2**(depth-round_idx))
         )
         for match_id in range(1,match_count+1):
-            KnockoutMatch.objects.create(round_number=round_idx, index_in_round=match_id,
+            match = KnockoutMatch.objects.create(round_number=round_idx, index_in_round=match_id,
                                          bracket=bracket, bo_type=bo_type)
+            
+            # Call game processor for match creation
+            if processor_class is not None:
+                api_data = processor_class.create_match(match)
+                if api_data is not None:
+                    match.api_data = api_data
+                    match.save(update_fields=['api_data'])
 
     if bracket.bracket_type == BracketType.DOUBLE:
         for round_idx in range(1,2*depth-1):
@@ -23,19 +37,34 @@ def create_empty_knockout_matchs(bracket: Bracket, bo_type: BestofType = BestofT
                 ceil(bracket.get_max_match_count()/2**(depth-(round_idx+1)//2))
             )
             for match_id in range(1,match_count+1):
-                KnockoutMatch.objects.create(
+                match = KnockoutMatch.objects.create(
                     round_number=round_idx,
                     index_in_round=match_id,
                     bracket=bracket,
                     bracket_set=BracketSet.LOOSER,
                     bo_type=bo_type,
                 )
-        KnockoutMatch.objects.create(
+                
+                # Call game processor for match creation
+                if processor_class is not None:
+                    api_data = processor_class.create_match(match)
+                    if api_data is not None:
+                        match.api_data = api_data
+                        match.save(update_fields=['api_data'])
+        
+        match = KnockoutMatch.objects.create(
             round_number=0,
             index_in_round=1,
             bracket=bracket,
             bo_type=bo_type,
         )
+        
+        # Call game processor for match creation
+        if processor_class is not None:
+            api_data = processor_class.create_match(match)
+            if api_data is not None:
+                match.api_data = api_data
+                match.save(update_fields=['api_data'])
 
 def update_next_knockout_match(match: KnockoutMatch) -> None:
     winners, loosers = match.get_winners_loosers()

--- a/insalan/tournament/manage/group.py
+++ b/insalan/tournament/manage/group.py
@@ -51,15 +51,27 @@ def create_group_matchs(group: Group, bo_type: BestofType = BestofType.BO1) -> N
     for gmatch in GroupMatch.objects.filter(group=group):
         gmatch.delete()
 
+    # Get game processor for match creation
+    processor_class = group.get_tournament().game.get_game_processor()
+    
     for round_idx in range(nb_rounds):
         matchs = []
         for match_idx in range(nb_matchs):
-            matchs.append(GroupMatch.objects.create(
+            match = GroupMatch.objects.create(
                 round_number=round_idx + 1,
                 index_in_round=match_idx + 1,
                 group=group,
                 bo_type=bo_type,
-            ))
+            )
+            
+            # Call game processor for match creation
+            if processor_class is not None:
+                api_data = processor_class.create_match(match)
+                if api_data is not None:
+                    match.api_data = api_data
+                    match.save(update_fields=['api_data'])
+            
+            matchs.append(match)
 
         matchs += matchs[::-1]
 

--- a/insalan/tournament/manage/group.py
+++ b/insalan/tournament/manage/group.py
@@ -53,7 +53,7 @@ def create_group_matchs(group: Group, bo_type: BestofType = BestofType.BO1) -> N
 
     # Get game processor for match creation
     processor_class = group.get_tournament().game.get_game_processor()
-    
+
     for round_idx in range(nb_rounds):
         matchs = []
         for match_idx in range(nb_matchs):
@@ -63,14 +63,14 @@ def create_group_matchs(group: Group, bo_type: BestofType = BestofType.BO1) -> N
                 group=group,
                 bo_type=bo_type,
             )
-            
+
             # Call game processor for match creation
             if processor_class is not None:
                 api_data = processor_class.create_match(match)
                 if api_data is not None:
                     match.api_data = api_data
                     match.save(update_fields=['api_data'])
-            
+
             matchs.append(match)
 
         matchs += matchs[::-1]

--- a/insalan/tournament/manage/match.py
+++ b/insalan/tournament/manage/match.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ..models import Match, MatchStatus, Score
+from ..models import Match, MatchStatus, Score, KnockoutMatch, GroupMatch, SwissMatch
 
 
 def update_match_score(match: Match, data: dict[str, Any]) -> None:
@@ -23,12 +23,6 @@ def launch_match(match: Match) -> None:
         score.save()
     else:
         match.status = MatchStatus.ONGOING
-        
-        # Call game processor for match start
-        from ..models.bracket import KnockoutMatch
-        from ..models.group import GroupMatch
-        from ..models.swiss import SwissMatch
-        
         # Get the tournament from the match
         tournament = None
         if hasattr(match, 'knockoutmatch'):
@@ -36,8 +30,8 @@ def launch_match(match: Match) -> None:
         elif hasattr(match, 'groupmatch'):
             tournament = GroupMatch.objects.get(id=match.id).group.tournament
         elif hasattr(match, 'swissmatch'):
-            tournament = SwissMatch.objects.get(id=match.id).round.tournament
-        
+            tournament = SwissMatch.objects.get(id=match.id).swiss.tournament
+
         if tournament is not None:
             processor_class = tournament.game.get_game_processor()
             if processor_class is not None:

--- a/insalan/tournament/manage/match.py
+++ b/insalan/tournament/manage/match.py
@@ -23,5 +23,26 @@ def launch_match(match: Match) -> None:
         score.save()
     else:
         match.status = MatchStatus.ONGOING
+        
+        # Call game processor for match start
+        from ..models.bracket import KnockoutMatch
+        from ..models.group import GroupMatch
+        from ..models.swiss import SwissMatch
+        
+        # Get the tournament from the match
+        tournament = None
+        if hasattr(match, 'knockoutmatch'):
+            tournament = KnockoutMatch.objects.get(id=match.id).bracket.tournament
+        elif hasattr(match, 'groupmatch'):
+            tournament = GroupMatch.objects.get(id=match.id).group.tournament
+        elif hasattr(match, 'swissmatch'):
+            tournament = SwissMatch.objects.get(id=match.id).round.tournament
+        
+        if tournament is not None:
+            processor_class = tournament.game.get_game_processor()
+            if processor_class is not None:
+                api_data = processor_class.start_match(match)
+                if api_data is not None:
+                    match.api_data = api_data
 
     match.save()

--- a/insalan/tournament/manage/swiss.py
+++ b/insalan/tournament/manage/swiss.py
@@ -35,14 +35,14 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
             score_group=0,
             bo_type=bo_type,
         )
-        
+
         # Call game processor for match creation
         if processor_class is not None:
             api_data = processor_class.create_match(match)
             if api_data is not None:
                 match.api_data = api_data
                 match.save(update_fields=['api_data'])
-        
+
         matchs.append(match)
 
     matchs_per_score_group_per_round.append([nb_matchs])
@@ -65,7 +65,7 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
                 score_group=0,
                 bo_type=bo_type,
             )
-            
+
             # Call game processor for match creation
             if processor_class is not None:
                 api_data = processor_class.create_match(match)
@@ -87,7 +87,7 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
                     score_group=j + 1,
                     bo_type=bo_type,
                 )
-                
+
                 # Call game processor for match creation
                 if processor_class is not None:
                     api_data = processor_class.create_match(match)
@@ -106,7 +106,7 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
                 score_group=round_idx,
                 bo_type=bo_type,
             )
-            
+
             # Call game processor for match creation
             if processor_class is not None:
                 api_data = processor_class.create_match(match)
@@ -133,7 +133,7 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
                     score_group=j,
                     bo_type=bo_type,
                 )
-                
+
                 # Call game processor for match creation
                 if processor_class is not None:
                     api_data = processor_class.create_match(match)

--- a/insalan/tournament/manage/swiss.py
+++ b/insalan/tournament/manage/swiss.py
@@ -16,19 +16,34 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
 
     matchs_per_score_group_per_round = []
 
+    # Get game processor for match deletion and creation
+    processor_class = swiss.tournament.game.get_game_processor()
+
     for match in SwissMatch.objects.filter(swiss=swiss):
+        # Call game processor for match deletion
+        if processor_class is not None:
+            processor_class.delete_match(match)
         match.delete()
 
     # first round
     matchs = []
     for match_idx in range(nb_matchs):
-        matchs.append(SwissMatch.objects.create(
+        match = SwissMatch.objects.create(
             round_number=1,
             index_in_round=match_idx + 1,
             swiss=swiss,
             score_group=0,
             bo_type=bo_type,
-        ))
+        )
+        
+        # Call game processor for match creation
+        if processor_class is not None:
+            api_data = processor_class.create_match(match)
+            if api_data is not None:
+                match.api_data = api_data
+                match.save(update_fields=['api_data'])
+        
+        matchs.append(match)
 
     matchs_per_score_group_per_round.append([nb_matchs])
 
@@ -43,13 +58,20 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
         match_idx = 0
 
         for idx in range(ceil(matchs_per_score_group_per_round[round_idx - 1][0] / 2)):
-            SwissMatch.objects.create(
+            match = SwissMatch.objects.create(
                 round_number=round_idx + 1,
                 index_in_round=idx + 1,
                 swiss=swiss,
                 score_group=0,
                 bo_type=bo_type,
             )
+            
+            # Call game processor for match creation
+            if processor_class is not None:
+                api_data = processor_class.create_match(match)
+                if api_data is not None:
+                    match.api_data = api_data
+                    match.save(update_fields=['api_data'])
 
         match_idx += idx + 1
         matchs_per_score_group_per_round.append([match_idx])
@@ -58,25 +80,39 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
             for idx in range(
                 ceil(sum(matchs_per_score_group_per_round[round_idx - 1][j:j + 2]) / 2)
             ):
-                SwissMatch.objects.create(
+                match = SwissMatch.objects.create(
                     round_number=round_idx + 1,
                     index_in_round=match_idx + idx + 1,
                     swiss=swiss,
                     score_group=j + 1,
                     bo_type=bo_type,
                 )
+                
+                # Call game processor for match creation
+                if processor_class is not None:
+                    api_data = processor_class.create_match(match)
+                    if api_data is not None:
+                        match.api_data = api_data
+                        match.save(update_fields=['api_data'])
 
             matchs_per_score_group_per_round[-1].append(idx + 1)
             match_idx += idx + 1
 
         for idx in range(ceil(matchs_per_score_group_per_round[round_idx - 1][-1] / 2)):
-            SwissMatch.objects.create(
+            match = SwissMatch.objects.create(
                 round_number=round_idx + 1,
                 index_in_round=match_idx + idx + 1,
                 swiss=swiss,
                 score_group=round_idx,
                 bo_type=bo_type,
             )
+            
+            # Call game processor for match creation
+            if processor_class is not None:
+                api_data = processor_class.create_match(match)
+                if api_data is not None:
+                    match.api_data = api_data
+                    match.save(update_fields=['api_data'])
 
         matchs_per_score_group_per_round[-1].append(idx + 1)
 
@@ -90,13 +126,20 @@ def create_swiss_matchs(swiss: SwissRound, bo_type: BestofType = BestofType.BO1)
             for idx in range(
                 ceil(sum(matchs_per_score_group_per_round[round_idx - 1][j:j + 2]) / 2)
             ):
-                SwissMatch.objects.create(
+                match = SwissMatch.objects.create(
                     round_number=round_idx + 1,
                     index_in_round=match_idx + idx + 1,
                     swiss=swiss,
                     score_group=j,
                     bo_type=bo_type,
                 )
+                
+                # Call game processor for match creation
+                if processor_class is not None:
+                    api_data = processor_class.create_match(match)
+                    if api_data is not None:
+                        match.api_data = api_data
+                        match.save(update_fields=['api_data'])
 
             matchs_per_score_group_per_round[-1].append(idx + 1)
             match_idx += idx + 1

--- a/insalan/tournament/models/__init__.py
+++ b/insalan/tournament/models/__init__.py
@@ -7,6 +7,7 @@ from .bracket import KnockoutMatch as KnockoutMatch
 from .event import Event as Event
 from .caster import Caster as Caster
 from .game import Game as Game
+from .game_processor import GameProcessor as GameProcessor
 from .group import Group as Group
 from .group import GroupMatch as GroupMatch
 from .group import GroupTiebreakScore as GroupTiebreakScore

--- a/insalan/tournament/models/game.py
+++ b/insalan/tournament/models/game.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Type
 
 from django.db import models
+from django.db.models import JSONField
 from django.core.validators import (
     MinValueValidator,
     MinLengthValidator,
@@ -10,6 +11,11 @@ from django.core.validators import (
 from django.utils.translation import gettext_lazy as _
 
 from .name_validator import NameValidator, get_choices, get_validator
+from .game_processor import (
+    GameProcessor,
+    get_processor_choices,
+    get_processor,
+)
 from .tournament import BaseTournament
 
 if TYPE_CHECKING:
@@ -71,6 +77,21 @@ class Game(models.Model):
         default=get_choices()[0][0],
         choices=get_choices(),
     )
+    game_processor = models.CharField(
+        verbose_name=_("Récupération des matchs"),
+        max_length=42,
+        null=False,
+        blank=False,
+        default=get_processor_choices()[0][0],
+        choices=get_processor_choices(),
+    )
+    games_parameters = JSONField(
+        verbose_name=_("Paramètres du jeu"),
+        blank=True,
+        null=True,
+        default=dict,
+        help_text=_("Paramètres JSON pour la configuration des API (ex: map pour LoL)"),
+    )
 
     def __str__(self) -> str:
         """Format this Game to a str"""
@@ -99,3 +120,7 @@ class Game(models.Model):
     def get_name_validator(self) -> Type[NameValidator] | None:
         """Return the validators of the game."""
         return get_validator(self.validators)
+
+    def get_game_processor(self) -> Type[GameProcessor] | None:
+        """Return the game processor of the game."""
+        return get_processor(self.game_processor)

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 import requests
 
 from insalan.settings import RIOT_API_KEY, WEBSITE_HOST, PROTOCOL
+from . import bracket, group, swiss
 
 if TYPE_CHECKING:
     from django_stubs_ext import StrPromise
@@ -32,12 +33,14 @@ class GameProcessor(ABC):
     """
     short: ClassVar[str]
     name: ClassVar[StrPromise]
-    
+
     # Default game parameters that will be used if not overridden
     default_game_parameters: ClassVar[dict[str, Any]] = {}
-    
+
     # Schema defining available parameters and their possible values
-    # Format: {"parameter_name": {"type": "choice|string|int|bool", "choices": [...], "label": "..."}}
+    # Format: {
+    #   "parameter_name": {"type": "choice|string|int|bool", "choices": [...], "label": "..."}
+    # }
     game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
 
     @staticmethod
@@ -129,7 +132,7 @@ class EmptyGameProcessor(GameProcessor):
     """
     short = "None"
     name = _("Pas de gestion automatique")
-    
+
     default_game_parameters: ClassVar[dict[str, Any]] = {}
     game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
 
@@ -165,13 +168,13 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
     """
     short = "LoL"
     name = _("League of Legends")
-    
+
     default_game_parameters: ClassVar[dict[str, Any]] = {
         "mapType": "SUMMONERS_RIFT",
         "pickType": "TOURNAMENT_DRAFT",
         "spectatorType": "ALL",
     }
-    
+
     game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {
         "pickType": {
             "type": "choice",
@@ -216,7 +219,7 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         3. Save both IDs in tournament ApiData
         """
         api_data: dict[str, Any] = {}
-        
+
         # Step 1: Create provider
         provider_response = requests.post(
             f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/providers",
@@ -227,13 +230,13 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             },
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )
-        
+
         if provider_response.status_code != 200:
             return None
-        
+
         provider_id = provider_response.json()
         api_data["providerID"] = provider_id
-        
+
         # Step 2: Create tournament
         tournament_response = requests.post(
             f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/tournaments",
@@ -244,13 +247,13 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             },
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )
-        
+
         if tournament_response.status_code != 200:
             return None
-        
+
         tournament_id = tournament_response.json()
         api_data["tournamentID"] = tournament_id
-        
+
         return api_data
 
     @staticmethod
@@ -261,38 +264,35 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         If no matches exist, reinitialize the tournament.
         """
         # Check if any matches exist for this tournament
-        from .bracket import Bracket
-        from .group import Group
-        from .swiss import SwissRound
-        
         has_matches = False
-        
+
         # Check brackets
-        for bracket in Bracket.objects.filter(tournament=tournament):
-            if bracket.matches.exists():
+        for bracketmatch in bracket.Bracket.objects.filter(tournament=tournament):
+            if bracketmatch.get_matchs().exists():
                 has_matches = True
                 break
-        
+
         # Check groups
         if not has_matches:
-            for group in Group.objects.filter(tournament=tournament):
-                if group.matches.exists():
+            for groupmatch in group.Group.objects.filter(tournament=tournament):
+                if groupmatch.get_matchs().exists():
                     has_matches = True
                     break
-        
+
         # Check swiss rounds
         if not has_matches:
-            for swiss_round in SwissRound.objects.filter(tournament=tournament):
-                if swiss_round.matches.exists():
+            for swiss_round in swiss.SwissRound.objects.filter(tournament=tournament):
+                if swiss_round.get_matchs().exists():
                     has_matches = True
                     break
-        
+
         if has_matches:
             raise ValidationError(
                 _("Impossible de rafraîchir le tournoi : des matchs ont déjà été créés. "
-                  "Pour League of Legends, le rafraîchissement ne peut être effectué qu'avant la création des matchs.")
+                  "Pour League of Legends, le rafraîchissement ne peut être effectué "
+                  "qu'avant la création des matchs.")
             )
-        
+
         # No matches exist, we can reinitialize
         return LeagueOfLegendsGameProcessor.initialize_tournament(tournament)
 
@@ -304,56 +304,52 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         The match needs access to its tournament to get the tournamentID.
         Creates N codes where N = best-of games (e.g., BO3 = 3 codes).
         """
-        # Get the tournament from the match
-        # We need to traverse through the match's parent structure
-        from .bracket import KnockoutMatch
-        from .group import GroupMatch
-        from .swiss import SwissMatch
-        
         tournament = None
         match_type = ""
-        
+
         # Determine which type of match this is and get its tournament
         if hasattr(match, 'knockoutmatch'):
-            knockout_match = KnockoutMatch.objects.get(id=match.id)
+            knockout_match = bracket.KnockoutMatch.objects.get(id=match.id)
             tournament = knockout_match.bracket.tournament
             match_type = "knockout"
         elif hasattr(match, 'groupmatch'):
-            group_match = GroupMatch.objects.get(id=match.id)
+            group_match = group.GroupMatch.objects.get(id=match.id)
             tournament = group_match.group.tournament
             match_type = "group"
         elif hasattr(match, 'swissmatch'):
-            swiss_match = SwissMatch.objects.get(id=match.id)
-            tournament = swiss_match.round.tournament
+            swiss_match = swiss.SwissMatch.objects.get(id=match.id)
+            tournament = swiss_match.swiss.tournament
             match_type = "swiss"
         else:
-            import sys
+            import sys  # pylint: disable=import-outside-toplevel
             print(f"Unknown match type for match ID {match.id}", file=sys.stderr)
             return None
-        
-        if tournament is None:
-            return None
-        
+
         # Check if tournament has provider data
         if not tournament.api_data or "tournamentID" not in tournament.api_data:
             # No provider configured, do nothing
             return {}
-        
+
         tournament_id = tournament.api_data["tournamentID"]
-        
+
         # Get games parameters from the game model
         game_parameters = tournament.game.games_parameters or {}
         game_parameters["teamSize"] = tournament.game.get_players_per_team()
-        game_parameters["metadata"] = f'{{"title":"{tournament.name} - Match {match.id}","tournament":"{tournament.id}","match":"{match.id}","match_type":"{match_type}"}}'
-        
+        metadata = (
+            f'{{"title":"{tournament.name} - Match {match.id}",'
+            f'"tournament":"{tournament.id}","match":"{match.id}",'
+            f'"match_type":"{match_type}"}}'
+        )
+        game_parameters["metadata"] = metadata
+
         # Determine the number of codes needed based on best-of type
-        from .match import BestofType
+        from .match import BestofType  # pylint: disable=import-outside-toplevel
         if match.bo_type == BestofType.RANKING:
             # For ranking matches, we don't create codes
             return {}
-        
+
         code_count = match.bo_type
-        
+
         # Create tournament codes
         codes_response = requests.post(
             f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/codes",
@@ -365,12 +361,12 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             json=game_parameters,
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )
-        
+
         if codes_response.status_code != 200:
             return None
-        
+
         codes = codes_response.json()
-        
+
         return {
             "pregame": codes,
             "postgame": {}
@@ -381,7 +377,7 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         """
         Start a match. For League of Legends, nothing needs to be done.
         """
-        return match.api_data
+        return match.api_data if isinstance(match.api_data, dict) else None
 
     @staticmethod
     def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -409,29 +405,29 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         """
         if not match.api_data:
             match.api_data = {"pregame": [], "postgame": {}}
-        
+
         if "postgame" not in match.api_data:
             match.api_data["postgame"] = {}
-        
+
         # Extract data from payload
         short_code = payload.get("shortCode")
         game_name = payload.get("gameName")  # This is the match PUUID
-        
+
         if not short_code or not game_name:
             return None
-        
+
         # Fetch match details from Riot API
         match_response = requests.get(
             f"{RIOT_MATCH_API_BASE}/lol/match/v5/matches/{game_name}",
             headers={"X-Riot-Token": RIOT_API_KEY},
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )
-        
+
         if match_response.status_code != 200:
             return None
-        
+
         match_data = match_response.json()
-        
+
         # TODO: Extract relevant statistics
         # Store essential match information
         game_stats = {
@@ -443,21 +439,21 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             "teams": match_data.get("info", {}).get("teams", []),
             "participants": match_data.get("info", {}).get("participants", []),
         }
-        
+
         # Save to postgame data keyed by tournament code
         match.api_data["postgame"][short_code] = game_stats
-        
+
         # Check if all games have finished
         pregame_codes = match.api_data.get("pregame", [])
         postgame_codes = match.api_data.get("postgame", {})
-        
+
         if len(postgame_codes) >= len(pregame_codes):
             # All games finished, mark match as completed
-            from .match import MatchStatus
+            from .match import MatchStatus  # pylint: disable=import-outside-toplevel
             match.status = MatchStatus.COMPLETED
             match.save(update_fields=["status", "api_data"])
-        
-        return match.api_data
+
+        return match.api_data if isinstance(match.api_data, dict) else None
 
     @staticmethod
     def delete_match(match: Match) -> None:
@@ -465,7 +461,6 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         Clean up match data. For League of Legends, no cleanup is required.
         Tournament codes remain valid but unused.
         """
-        pass
 
 
 processors: list[Type[GameProcessor]] = [

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -18,7 +18,7 @@ from .match import MatchStatus
 if TYPE_CHECKING:
     from django_stubs_ext import StrPromise
 
-    from .tournament import EventTournament
+    from .tournament import BaseTournament
     from .match import Match
 
 
@@ -46,7 +46,7 @@ class GameProcessor(ABC):
 
     @staticmethod
     @abstractmethod
-    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def initialize_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         """
         Make the required API calls and return the data to save in the ApiData field of tournament.
         Will be called when tournament is created.
@@ -60,7 +60,7 @@ class GameProcessor(ABC):
 
     @staticmethod
     @abstractmethod
-    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def update_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         """
         Make the required API calls and return the data to save in the ApiData field of tournament.
         Will be called with tournament action.
@@ -138,11 +138,11 @@ class EmptyGameProcessor(GameProcessor):
     game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
 
     @staticmethod
-    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def initialize_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         return {}
 
     @staticmethod
-    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def update_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         return {}
 
     @staticmethod
@@ -210,7 +210,7 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
     }
 
     @staticmethod
-    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def initialize_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         """
         Initialize a League of Legends tournament by creating a provider and tournament ID.
         
@@ -258,7 +258,7 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         return api_data
 
     @staticmethod
-    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+    def update_tournament(tournament: BaseTournament) -> dict[str, Any] | None:
         """
         Refresh tournament data. For LoL, this can only be done if no matches were created.
         If matches exist, raise an exception to inform the admin.

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -13,6 +13,7 @@ import requests
 
 from insalan.settings import RIOT_API_KEY, WEBSITE_HOST, PROTOCOL
 from . import bracket, group, swiss
+from .match import MatchStatus
 
 if TYPE_CHECKING:
     from django_stubs_ext import StrPromise
@@ -411,14 +412,16 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
 
         # Extract data from payload
         short_code = payload.get("shortCode")
-        game_name = payload.get("gameName")  # This is the match PUUID
+        game_id_raw = payload.get("gameId")
 
-        if not short_code or not game_name:
+        if not short_code or not game_id_raw:
             return None
+
+        game_id = f"EUW1_{game_id_raw}"
 
         # Fetch match details from Riot API
         match_response = requests.get(
-            f"{RIOT_MATCH_API_BASE}/lol/match/v5/matches/{game_name}",
+            f"{RIOT_MATCH_API_BASE}/lol/match/v5/matches/{game_id}",
             headers={"X-Riot-Token": RIOT_API_KEY},
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )
@@ -431,11 +434,9 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         # TODO: Extract relevant statistics
         # Store essential match information
         game_stats = {
-            "gameId": payload.get("gameId"),
-            "gameName": game_name,
+            "gameId": game_id,
             "startTime": payload.get("startTime"),
             "gameDuration": match_data.get("info", {}).get("gameDuration"),
-            "gameMode": payload.get("gameMode"),
             "teams": match_data.get("info", {}).get("teams", []),
             "participants": match_data.get("info", {}).get("participants", []),
         }
@@ -447,11 +448,73 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         pregame_codes = match.api_data.get("pregame", [])
         postgame_codes = match.api_data.get("postgame", {})
 
-        if len(postgame_codes) >= len(pregame_codes):
-            # All games finished, mark match as completed
-            from .match import MatchStatus  # pylint: disable=import-outside-toplevel
-            match.status = MatchStatus.COMPLETED
-            match.save(update_fields=["status", "api_data"])
+        if len(postgame_codes) >= len(pregame_codes) and match.status != MatchStatus.COMPLETED:
+            # All games finished, extract winners and determine final score
+            from ..manage.match import update_match_score  # pylint: disable=import-outside-toplevel
+            from ..manage.bracket import update_next_knockout_match  # pylint: disable=import-outside-toplevel
+            from .bracket import KnockoutMatch  # pylint: disable=import-outside-toplevel
+
+            # Initialize score dict for each team
+            team_scores: dict[str, int] = {}
+            for team in match.get_teams():
+                team_scores[str(team.id)] = 0
+
+            # Count wins for each team by analyzing postgame data
+            for game_data in postgame_codes.values():
+                participants = game_data.get("participants", [])
+                teams_data = game_data.get("teams", [])
+
+                # Find winning team ID from teams data
+                winning_team_id = None
+                for team_info in teams_data:
+                    if team_info.get("win"):
+                        winning_team_id = team_info.get("teamId")
+                        break
+
+                if winning_team_id is None:
+                    continue
+
+                # Get PUUIDs of players in the winning team
+                winning_puuids = set()
+                for participant in participants:
+                    if participant.get("teamId") == winning_team_id:
+                        puuid = participant.get("puuid")
+                        if puuid:
+                            winning_puuids.add(puuid)
+
+                # Match PUUIDs to our teams via Player.validator_data
+                for team in match.get_teams():
+                    team_players = team.get_players()
+                    team_puuids = set()
+                    for player in team_players:
+                        player_puuid = player.validator_data.get("puuid")
+                        if player_puuid:
+                            team_puuids.add(player_puuid)
+
+                    # Check if this team's PUUIDs overlap with winning PUUIDs
+                    # If at least one player matches, this team won the game
+                    if team_puuids & winning_puuids:
+                        team_scores[str(team.id)] += 1
+                        break
+
+            # Extract game durations
+            times = []
+            for game_data in postgame_codes.values():
+                duration = game_data.get("gameDuration", 0)
+                # Convert from seconds to minutes
+                times.append(duration // 60 if duration else 0)
+
+            # Update match with final scores
+            score_data = {
+                "score": {str(team_id): score for team_id, score in team_scores.items()},
+                "times": times
+            }
+
+            update_match_score(match, score_data)
+
+            # Propagate results if this is a bracket match
+            if isinstance(match, KnockoutMatch) and not match.is_last_match():
+                update_next_knockout_match(match)
 
         return match.api_data if isinstance(match.api_data, dict) else None
 

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -384,6 +384,70 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         return match.api_data if isinstance(match.api_data, dict) else None
 
     @staticmethod
+    def _filter_match_data(game_id: str, start_time: int | None, match_data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Filter match data to keep only useful post-game information.
+        
+        Args:
+            game_id: The game ID
+            start_time: Game start timestamp
+            match_data: Raw match data from Riot API
+            
+        Returns:
+            Filtered dictionary with only essential statistics
+        """
+        info = match_data.get("info", {})
+
+        # Filter team data
+        teams = []
+        for team in info.get("teams", []):
+            teams.append({
+                "teamId": team.get("teamId"),
+                "win": team.get("win"),
+                "bans": team.get("bans", []),
+                "objectives": team.get("objectives", {}),
+            })
+
+        # Filter participant data
+        participants = []
+        for participant in info.get("participants", []):
+            participants.append({
+                "puuid": participant.get("puuid"),
+                "teamId": participant.get("teamId"),
+                "championId": participant.get("championId"),
+                "championName": participant.get("championName"),
+                "champLevel": participant.get("champLevel"),
+                "kills": participant.get("kills"),
+                "deaths": participant.get("deaths"),
+                "assists": participant.get("assists"),
+                "totalMinionsKilled": participant.get("totalMinionsKilled"),
+                "profileIcon": participant.get("profileIcon"),
+                "role": participant.get("role"),
+                "lane": participant.get("lane"),
+                "goldEarned": participant.get("goldEarned"),
+                "totalDamageDealtToChampions": participant.get("totalDamageDealtToChampions"),
+                "visionScore": participant.get("visionScore"),
+                "item0": participant.get("item0"),
+                "item1": participant.get("item1"),
+                "item2": participant.get("item2"),
+                "item3": participant.get("item3"),
+                "item4": participant.get("item4"),
+                "item5": participant.get("item5"),
+                "item6": participant.get("item6"),
+                "summoner1Id": participant.get("summoner1Id"),
+                "summoner2Id": participant.get("summoner2Id"),
+                "perks": participant.get("perks", {}),
+            })
+
+        return {
+            "gameId": game_id,
+            "startTime": start_time,
+            "gameDuration": info.get("gameDuration"),
+            "teams": teams,
+            "participants": participants,
+        }
+
+    @staticmethod
     def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None:
         """
         Process match results from a callback.
@@ -434,15 +498,12 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
 
         match_data = match_response.json()
 
-        # TODO: Extract relevant statistics
-        # Store essential match information
-        game_stats = {
-            "gameId": game_id,
-            "startTime": payload.get("startTime"),
-            "gameDuration": match_data.get("info", {}).get("gameDuration"),
-            "teams": match_data.get("info", {}).get("teams", []),
-            "participants": match_data.get("info", {}).get("participants", []),
-        }
+        # Filter and store essential match information
+        game_stats = LeagueOfLegendsGameProcessor._filter_match_data(
+            game_id=game_id,
+            start_time=payload.get("startTime"),
+            match_data=match_data
+        )
 
         # Save to postgame data keyed by tournament code
         match.api_data["postgame"][short_code] = game_stats

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -226,8 +226,11 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/providers",
             headers={"X-Riot-Token": RIOT_API_KEY},
             json={
-                "region": "EUW",  # Europe West region
-                "url": f"{PROTOCOL}://api.{WEBSITE_HOST}/v1/tournament/tournament/{tournament.id}/result/"
+            "region": "EUW",  # Europe West region
+            "url": (
+                f"{PROTOCOL}://api.{WEBSITE_HOST}/v1/tournament/"
+                f"tournament/{tournament.id}/result/"
+            )
             },
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -227,7 +227,7 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
             headers={"X-Riot-Token": RIOT_API_KEY},
             json={
                 "region": "EUW",  # Europe West region
-                "url": f"${PROTOCOL}://api.${WEBSITE_HOST}/api/tournament/{tournament.id}/result"
+                "url": f"{PROTOCOL}://api.{WEBSITE_HOST}/v1/tournament/tournament/{tournament.id}/result/"
             },
             timeout=REQUESTS_TIMEOUT_SECONDS,
         )

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -1,0 +1,511 @@
+"""
+GameProcessor class
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Type, TYPE_CHECKING
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+import requests
+
+from insalan.settings import RIOT_API_KEY, WEBSITE_HOST, PROTOCOL
+
+if TYPE_CHECKING:
+    from django_stubs_ext import StrPromise
+
+    from .tournament import EventTournament
+    from .match import Match
+
+
+REQUESTS_TIMEOUT_SECONDS: int = 5
+RIOT_TOURNAMENT_API_BASE: str = "https://americas.api.riotgames.com"
+RIOT_MATCH_API_BASE: str = "https://europe.api.riotgames.com"
+
+
+class GameProcessor(ABC):
+    """
+    Abstract base class for game-specific processors.
+    Each game that supports automatic match handling should implement this class.
+    """
+    short: ClassVar[str]
+    name: ClassVar[StrPromise]
+    
+    # Default game parameters that will be used if not overridden
+    default_game_parameters: ClassVar[dict[str, Any]] = {}
+    
+    # Schema defining available parameters and their possible values
+    # Format: {"parameter_name": {"type": "choice|string|int|bool", "choices": [...], "label": "..."}}
+    game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
+
+    @staticmethod
+    @abstractmethod
+    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        """
+        Make the required API calls and return the data to save in the ApiData field of tournament.
+        Will be called when tournament is created.
+        
+        Args:
+            tournament: The tournament to initialize
+            
+        Returns:
+            Dictionary containing API data to store, or None if initialization failed
+        """
+
+    @staticmethod
+    @abstractmethod
+    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        """
+        Make the required API calls and return the data to save in the ApiData field of tournament.
+        Will be called with tournament action.
+        
+        Args:
+            tournament: The tournament to update
+            
+        Returns:
+            Dictionary containing updated API data to store, or None if update failed
+        """
+
+    @staticmethod
+    @abstractmethod
+    def create_match(match: Match) -> dict[str, Any] | None:
+        """
+        Make the required API calls and return the data to save in the ApiData field of match.
+        Will be called when match is created.
+        
+        Args:
+            match: The match to create
+            
+        Returns:
+            Dictionary containing API data to store, or None if creation failed
+        """
+
+    @staticmethod
+    @abstractmethod
+    def start_match(match: Match) -> dict[str, Any] | None:
+        """
+        Make the required API calls and return the data to save in the ApiData field of match.
+        Will be called when match status is set to started.
+        
+        Args:
+            match: The match to start
+            
+        Returns:
+            Dictionary containing updated API data to store, or None if start failed
+        """
+
+    @staticmethod
+    @abstractmethod
+    def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None:
+        """
+        Make the required API calls and return the data to save in the ApiData field of match.
+        Will be called upon match callback (if API).
+        
+        Args:
+            match: The match to process results for
+            payload: Data received from the callback
+            
+        Returns:
+            Dictionary containing updated API data to store, or None if processing failed
+        """
+
+    @staticmethod
+    @abstractmethod
+    def delete_match(match: Match) -> None:
+        """
+        Make the required API calls to clean up match data.
+        Will be called upon match destruction.
+        
+        Args:
+            match: The match being deleted
+        """
+
+
+class EmptyGameProcessor(GameProcessor):
+    """
+    Default game processor that performs no automatic match handling.
+    """
+    short = "None"
+    name = _("Pas de gestion automatique")
+    
+    default_game_parameters: ClassVar[dict[str, Any]] = {}
+    game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {}
+
+    @staticmethod
+    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        return {}
+
+    @staticmethod
+    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        return {}
+
+    @staticmethod
+    def create_match(match: Match) -> dict[str, Any] | None:
+        return {}
+
+    @staticmethod
+    def start_match(match: Match) -> dict[str, Any] | None:
+        return {}
+
+    @staticmethod
+    def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None:
+        return {}
+
+    @staticmethod
+    def delete_match(match: Match) -> None:
+        pass
+
+
+class LeagueOfLegendsGameProcessor(GameProcessor):
+    """
+    Game processor for League of Legends automatic match handling.
+    Uses Riot's Tournament API v5 to create and manage tournament codes.
+    """
+    short = "LoL"
+    name = _("League of Legends")
+    
+    default_game_parameters: ClassVar[dict[str, Any]] = {
+        "mapType": "SUMMONERS_RIFT",
+        "pickType": "TOURNAMENT_DRAFT",
+        "spectatorType": "ALL",
+    }
+    
+    game_parameters_schema: ClassVar[dict[str, dict[str, Any]]] = {
+        "pickType": {
+            "type": "choice",
+            "label": _("Type de sélection"),
+            "choices": [
+                ("BLIND_PICK", _("Sélection aveugle")),
+                ("DRAFT_MODE", _("Mode draft")),
+                ("ALL_RANDOM", _("Tout aléatoire")),
+                ("TOURNAMENT_DRAFT", _("Draft tournoi")),
+            ],
+            "help_text": _("Le mode de sélection des champions")
+        },
+        "mapType": {
+            "type": "choice",
+            "label": _("Type de carte"),
+            "choices": [
+                ("SUMMONERS_RIFT", _("Faille de l'invocateur")),
+                ("HOWLING_ABYSS", _("Abîme hurlant")),
+            ],
+            "help_text": _("La carte sur laquelle se déroulera le match")
+        },
+        "spectatorType": {
+            "type": "choice",
+            "label": _("Type de spectateur"),
+            "choices": [
+                ("NONE", _("Aucun")),
+                ("LOBBYONLY", _("Lobby uniquement")),
+                ("ALL", _("Tous")),
+            ],
+            "help_text": _("Qui peut observer le match")
+        }
+    }
+
+    @staticmethod
+    def initialize_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        """
+        Initialize a League of Legends tournament by creating a provider and tournament ID.
+        
+        Steps:
+        1. Create a provider via POST /lol/tournament/v5/providers
+        2. Create a tournament via POST /lol/tournament/v5/tournaments
+        3. Save both IDs in tournament ApiData
+        """
+        api_data: dict[str, Any] = {}
+        
+        # Step 1: Create provider
+        provider_response = requests.post(
+            f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/providers",
+            headers={"X-Riot-Token": RIOT_API_KEY},
+            json={
+                "region": "EUW",  # Europe West region
+                "url": f"${PROTOCOL}://api.${WEBSITE_HOST}/api/tournament/{tournament.id}/result"
+            },
+            timeout=REQUESTS_TIMEOUT_SECONDS,
+        )
+        
+        if provider_response.status_code != 200:
+            return None
+        
+        provider_id = provider_response.json()
+        api_data["providerID"] = provider_id
+        
+        # Step 2: Create tournament
+        tournament_response = requests.post(
+            f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/tournaments",
+            headers={"X-Riot-Token": RIOT_API_KEY},
+            json={
+                "providerId": provider_id,
+                "name": tournament.name,
+            },
+            timeout=REQUESTS_TIMEOUT_SECONDS,
+        )
+        
+        if tournament_response.status_code != 200:
+            return None
+        
+        tournament_id = tournament_response.json()
+        api_data["tournamentID"] = tournament_id
+        
+        return api_data
+
+    @staticmethod
+    def update_tournament(tournament: EventTournament) -> dict[str, Any] | None:
+        """
+        Refresh tournament data. For LoL, this can only be done if no matches were created.
+        If matches exist, raise an exception to inform the admin.
+        If no matches exist, reinitialize the tournament.
+        """
+        # Check if any matches exist for this tournament
+        from .bracket import Bracket
+        from .group import Group
+        from .swiss import SwissRound
+        
+        has_matches = False
+        
+        # Check brackets
+        for bracket in Bracket.objects.filter(tournament=tournament):
+            if bracket.matches.exists():
+                has_matches = True
+                break
+        
+        # Check groups
+        if not has_matches:
+            for group in Group.objects.filter(tournament=tournament):
+                if group.matches.exists():
+                    has_matches = True
+                    break
+        
+        # Check swiss rounds
+        if not has_matches:
+            for swiss_round in SwissRound.objects.filter(tournament=tournament):
+                if swiss_round.matches.exists():
+                    has_matches = True
+                    break
+        
+        if has_matches:
+            raise ValidationError(
+                _("Impossible de rafraîchir le tournoi : des matchs ont déjà été créés. "
+                  "Pour League of Legends, le rafraîchissement ne peut être effectué qu'avant la création des matchs.")
+            )
+        
+        # No matches exist, we can reinitialize
+        return LeagueOfLegendsGameProcessor.initialize_tournament(tournament)
+
+    @staticmethod
+    def create_match(match: Match) -> dict[str, Any] | None:
+        """
+        Create tournament codes for a League of Legends match.
+        
+        The match needs access to its tournament to get the tournamentID.
+        Creates N codes where N = best-of games (e.g., BO3 = 3 codes).
+        """
+        # Get the tournament from the match
+        # We need to traverse through the match's parent structure
+        from .bracket import KnockoutMatch
+        from .group import GroupMatch
+        from .swiss import SwissMatch
+        
+        tournament = None
+        match_type = ""
+        
+        # Determine which type of match this is and get its tournament
+        if hasattr(match, 'knockoutmatch'):
+            knockout_match = KnockoutMatch.objects.get(id=match.id)
+            tournament = knockout_match.bracket.tournament
+            match_type = "knockout"
+        elif hasattr(match, 'groupmatch'):
+            group_match = GroupMatch.objects.get(id=match.id)
+            tournament = group_match.group.tournament
+            match_type = "group"
+        elif hasattr(match, 'swissmatch'):
+            swiss_match = SwissMatch.objects.get(id=match.id)
+            tournament = swiss_match.round.tournament
+            match_type = "swiss"
+        else:
+            import sys
+            print(f"Unknown match type for match ID {match.id}", file=sys.stderr)
+            return None
+        
+        if tournament is None:
+            return None
+        
+        # Check if tournament has provider data
+        if not tournament.api_data or "tournamentID" not in tournament.api_data:
+            # No provider configured, do nothing
+            return {}
+        
+        tournament_id = tournament.api_data["tournamentID"]
+        
+        # Get games parameters from the game model
+        game_parameters = tournament.game.games_parameters or {}
+        game_parameters["teamSize"] = tournament.game.get_players_per_team()
+        game_parameters["metadata"] = f'{{"title":"{tournament.name} - Match {match.id}","tournament":"{tournament.id}","match":"{match.id}","match_type":"{match_type}"}}'
+        
+        # Determine the number of codes needed based on best-of type
+        from .match import BestofType
+        if match.bo_type == BestofType.RANKING:
+            # For ranking matches, we don't create codes
+            return {}
+        
+        code_count = match.bo_type
+        
+        # Create tournament codes
+        codes_response = requests.post(
+            f"{RIOT_TOURNAMENT_API_BASE}/lol/tournament/v5/codes",
+            headers={"X-Riot-Token": RIOT_API_KEY},
+            params={
+                "tournamentId": tournament_id,
+                "count": code_count,
+            },
+            json=game_parameters,
+            timeout=REQUESTS_TIMEOUT_SECONDS,
+        )
+        
+        if codes_response.status_code != 200:
+            return None
+        
+        codes = codes_response.json()
+        
+        return {
+            "pregame": codes,
+            "postgame": {}
+        }
+
+    @staticmethod
+    def start_match(match: Match) -> dict[str, Any] | None:
+        """
+        Start a match. For League of Legends, nothing needs to be done.
+        """
+        return match.api_data
+
+    @staticmethod
+    def process_result_match(match: Match, payload: dict[str, Any]) -> dict[str, Any] | None:
+        """
+        Process match results from a callback.
+        
+        Payload example:
+        {
+          "startTime": 1234567890000,
+          "shortCode": "NA1234a-1a23b456-a1b2-1abc-ab12-1234567890ab",
+          "metaData": "{\\"title\\":\\"Game 42 - Finals\\"}",
+          "gameId": 1234567890,
+          "gameName": "a123bc45-ab1c-1a23-ab12-12345a67b89c",
+          "gameType": "Practice",
+          "gameMap": 11,
+          "gameMode": "CLASSIC",
+          "region": "NA1"
+        }
+        
+        Steps:
+        1. Extract match PUUID from payload (gameName field)
+        2. Fetch match details from Riot API
+        3. Process and save statistics to match.api_data.postgame[shortCode]
+        4. Check if all games have finished, mark match as completed if so
+        """
+        if not match.api_data:
+            match.api_data = {"pregame": [], "postgame": {}}
+        
+        if "postgame" not in match.api_data:
+            match.api_data["postgame"] = {}
+        
+        # Extract data from payload
+        short_code = payload.get("shortCode")
+        game_name = payload.get("gameName")  # This is the match PUUID
+        
+        if not short_code or not game_name:
+            return None
+        
+        # Fetch match details from Riot API
+        match_response = requests.get(
+            f"{RIOT_MATCH_API_BASE}/lol/match/v5/matches/{game_name}",
+            headers={"X-Riot-Token": RIOT_API_KEY},
+            timeout=REQUESTS_TIMEOUT_SECONDS,
+        )
+        
+        if match_response.status_code != 200:
+            return None
+        
+        match_data = match_response.json()
+        
+        # TODO: Extract relevant statistics
+        # Store essential match information
+        game_stats = {
+            "gameId": payload.get("gameId"),
+            "gameName": game_name,
+            "startTime": payload.get("startTime"),
+            "gameDuration": match_data.get("info", {}).get("gameDuration"),
+            "gameMode": payload.get("gameMode"),
+            "teams": match_data.get("info", {}).get("teams", []),
+            "participants": match_data.get("info", {}).get("participants", []),
+        }
+        
+        # Save to postgame data keyed by tournament code
+        match.api_data["postgame"][short_code] = game_stats
+        
+        # Check if all games have finished
+        pregame_codes = match.api_data.get("pregame", [])
+        postgame_codes = match.api_data.get("postgame", {})
+        
+        if len(postgame_codes) >= len(pregame_codes):
+            # All games finished, mark match as completed
+            from .match import MatchStatus
+            match.status = MatchStatus.COMPLETED
+            match.save(update_fields=["status", "api_data"])
+        
+        return match.api_data
+
+    @staticmethod
+    def delete_match(match: Match) -> None:
+        """
+        Clean up match data. For League of Legends, no cleanup is required.
+        Tournament codes remain valid but unused.
+        """
+        pass
+
+
+processors: list[Type[GameProcessor]] = [
+    EmptyGameProcessor,
+    LeagueOfLegendsGameProcessor,
+]
+
+
+def get_processor_choices() -> list[tuple[str, StrPromise]]:
+    """
+    Get the choices for the game processors
+    """
+    return [(processor.short, processor.name) for processor in processors]
+
+
+def get_processor(name: str) -> Type[GameProcessor] | None:
+    """
+    Get the game processor from a name
+    """
+    for processor in processors:
+        if processor.short == name:
+            return processor
+    return None
+
+
+def get_processor_default_parameters(processor_name: str) -> dict[str, Any]:
+    """
+    Get the default game parameters for a processor
+    """
+    processor = get_processor(processor_name)
+    if processor is None:
+        return {}
+    return processor.default_game_parameters.copy()
+
+
+def get_processor_parameters_schema(processor_name: str) -> dict[str, dict[str, Any]]:
+    """
+    Get the game parameters schema for a processor
+    """
+    processor = get_processor(processor_name)
+    if processor is None:
+        return {}
+    return processor.game_parameters_schema.copy()

--- a/insalan/tournament/models/game_processor.py
+++ b/insalan/tournament/models/game_processor.py
@@ -384,7 +384,11 @@ class LeagueOfLegendsGameProcessor(GameProcessor):
         return match.api_data if isinstance(match.api_data, dict) else None
 
     @staticmethod
-    def _filter_match_data(game_id: str, start_time: int | None, match_data: dict[str, Any]) -> dict[str, Any]:
+    def _filter_match_data(
+        game_id: str,
+        start_time: int | None,
+        match_data: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Filter match data to keep only useful post-game information.
         

--- a/insalan/tournament/models/match.py
+++ b/insalan/tournament/models/match.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import JSONField
 from django.db.models.query import QuerySet
 from django.utils.translation import gettext_lazy as _
 
@@ -65,6 +66,13 @@ class Match(models.Model):
         verbose_name=_("Liste des durées des parties du match"),
         default=list,
         blank=True
+    )
+    api_data = JSONField(
+        verbose_name=_("Données API"),
+        blank=True,
+        null=True,
+        default=dict,
+        help_text=_("Données JSON pour l'automatisation du match"),
     )
 
     class Meta:

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -449,6 +449,8 @@ class EventTournament(BaseTournament):
         is_new = self.pk is None
         super().save(*args, **kwargs)  # Get the self accessible to the products
 
+        need_save = False
+
         # Initialize tournament with game processor if this is a new tournament
         if is_new:
             processor_class = self.game.get_game_processor()
@@ -456,8 +458,7 @@ class EventTournament(BaseTournament):
                 api_data = processor_class.initialize_tournament(self)
                 if api_data is not None:
                     self.api_data = api_data
-
-        need_save = False
+                    need_save = True
 
         if self.player_online_product is None:
             prod = Product.objects.create(

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -6,6 +6,7 @@ from typing import Any, cast, TYPE_CHECKING
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from django.db.models import JSONField
 from django.db.models.manager import Manager
 from django.db.models.query import QuerySet
 from django.core.validators import (
@@ -418,6 +419,13 @@ class EventTournament(BaseTournament):
         upload_to="tournament-planning",
         validators=[FileExtensionValidator(allowed_extensions=["ics"])],
     )
+    api_data = JSONField(
+        verbose_name=_("Données API"),
+        blank=True,
+        null=True,
+        default=dict,
+        help_text=_("Données JSON pour l'automatisation des matchs"),
+    )
 
     class Meta:
         """Meta options"""
@@ -438,7 +446,16 @@ class EventTournament(BaseTournament):
         # pylint: disable=import-outside-toplevel
         from insalan.payment.models import Product, ProductCategory
 
+        is_new = self.pk is None
         super().save(*args, **kwargs)  # Get the self accessible to the products
+
+        # Initialize tournament with game processor if this is a new tournament
+        if is_new:
+            processor_class = self.game.get_game_processor()
+            if processor_class is not None:
+                api_data = processor_class.initialize_tournament(self)
+                if api_data is not None:
+                    self.api_data = api_data
 
         need_save = False
 

--- a/insalan/tournament/models/tournament.py
+++ b/insalan/tournament/models/tournament.py
@@ -93,6 +93,13 @@ class BaseTournament(PolymorphicModel):  # type: ignore[misc]
         verbose_name=_("Description du tournoi en bas de page"),
         max_length=300,
     )
+    api_data = JSONField(
+        verbose_name=_("Données API"),
+        blank=True,
+        null=True,
+        default=dict,
+        help_text=_("Données JSON pour l'automatisation des matchs"),
+    )
 
     # The teams field is defined in the tournament field in the Team model as
     # realated name but mypy doesn't detect it.
@@ -259,6 +266,16 @@ class BaseTournament(PolymorphicModel):  # type: ignore[misc]
             for substitute in team_obj.get_substitutes():
                 substitute.update_name_in_game()
 
+    def initialize_game_processor(self) -> bool:
+        """Initialize tournament with game processor if available. Returns True if initialized."""
+        processor_class = self.game.get_game_processor()
+        if processor_class is not None:
+            api_data = processor_class.initialize_tournament(self)
+            if api_data is not None:
+                self.api_data = api_data
+                return True
+        return False
+
 class PrivateTournament(BaseTournament):
     """
     A private Tournament without paid registration.
@@ -291,6 +308,15 @@ class PrivateTournament(BaseTournament):
         blank=True,
         default="",
     )
+
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        """Override default save to initialize game processor for new tournaments"""
+        is_new = self.pk is None
+        super().save(*args, **kwargs)
+
+        # Initialize tournament with game processor if this is a new tournament
+        if is_new and self.initialize_game_processor():
+            super().save(update_fields=['api_data'])
 
     class Meta:
         """Meta options"""
@@ -419,13 +445,6 @@ class EventTournament(BaseTournament):
         upload_to="tournament-planning",
         validators=[FileExtensionValidator(allowed_extensions=["ics"])],
     )
-    api_data = JSONField(
-        verbose_name=_("Données API"),
-        blank=True,
-        null=True,
-        default=dict,
-        help_text=_("Données JSON pour l'automatisation des matchs"),
-    )
 
     class Meta:
         """Meta options"""
@@ -452,13 +471,8 @@ class EventTournament(BaseTournament):
         need_save = False
 
         # Initialize tournament with game processor if this is a new tournament
-        if is_new:
-            processor_class = self.game.get_game_processor()
-            if processor_class is not None:
-                api_data = processor_class.initialize_tournament(self)
-                if api_data is not None:
-                    self.api_data = api_data
-                    need_save = True
+        if is_new and self.initialize_game_processor():
+            need_save = True
 
         if self.player_online_product is None:
             prod = Product.objects.create(

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -574,6 +574,7 @@ class GameSerializer(serializers.ModelSerializer[Game]):
             "players_per_team",
             "substitute_players_per_team",
             "team_per_match",
+            "game_processor",
         )
 
 class EventTournamentSerializer(serializers.ModelSerializer[EventTournament]):

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -562,14 +562,6 @@ class EventSerializer(serializers.ModelSerializer[Event]):
 class GameSerializer(serializers.ModelSerializer[Game]):
     """Serializer for the tournament Games"""
 
-    game_processor = serializers.SerializerMethodField()
-
-    def get_game_processor(self, obj: Game) -> str | None:
-        """Return None instead of 'None' string for empty game processor"""
-        if obj.game_processor == "None" or not obj.game_processor:
-            return None
-        return obj.game_processor
-
     class Meta:
         """Meta options of the serializer"""
 

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -562,6 +562,14 @@ class EventSerializer(serializers.ModelSerializer[Event]):
 class GameSerializer(serializers.ModelSerializer[Game]):
     """Serializer for the tournament Games"""
 
+    game_processor = serializers.SerializerMethodField()
+
+    def get_game_processor(self, obj: Game) -> str | None:
+        """Return None instead of 'None' string for empty game processor"""
+        if obj.game_processor == "None" or not obj.game_processor:
+            return None
+        return obj.game_processor
+
     class Meta:
         """Meta options of the serializer"""
 
@@ -600,7 +608,7 @@ class EventTournamentSerializer(serializers.ModelSerializer[EventTournament]):
             "substitute_price_online",
             "substitute_price_onsite",
         )
-        exclude = ["polymorphic_ctype"]
+        exclude = ["polymorphic_ctype", "api_data"]
 
     def to_representation(self, instance: EventTournament) -> Any:
         """Remove all fields except id and is_announced when is_announced is False"""
@@ -1182,7 +1190,7 @@ class FullDerefEventTournamentSerializer(serializers.ModelSerializer[EventTourna
 
     class Meta:
         model = EventTournament
-        exclude = ["polymorphic_ctype"]
+        exclude = ["polymorphic_ctype", "api_data"]
 
     def to_representation(self, value: EventTournament) -> Any:
         if value.is_announced:

--- a/insalan/tournament/test/test_event_tournament.py
+++ b/insalan/tournament/test/test_event_tournament.py
@@ -344,11 +344,6 @@ class TournamentFullDerefEndpoint(APITestCase):
                 }
             ]
         }
-        
-        # Debug
-        import sys
-        print(request.data, file=sys.stderr)
-        print(model, file=sys.stderr)
 
         self.assertEqual(request.data["teams"], model["teams"])
         self.assertEqual(request.data, model)

--- a/insalan/tournament/test/test_event_tournament.py
+++ b/insalan/tournament/test/test_event_tournament.py
@@ -271,7 +271,8 @@ class TournamentFullDerefEndpoint(APITestCase):
                 "short_name": "TFG",
                 "players_per_team": 1,
                 "substitute_players_per_team": 0,
-                "team_per_match": 2
+                "team_per_match": 2,
+                "game_processor": None
             },
             "name": "Test Tournament",
             "rules": "have fun!",
@@ -343,6 +344,11 @@ class TournamentFullDerefEndpoint(APITestCase):
                 }
             ]
         }
+        
+        # Debug
+        import sys
+        print(request.data, file=sys.stderr)
+        print(model, file=sys.stderr)
 
         self.assertEqual(request.data["teams"], model["teams"])
         self.assertEqual(request.data, model)

--- a/insalan/tournament/test/test_event_tournament.py
+++ b/insalan/tournament/test/test_event_tournament.py
@@ -272,7 +272,7 @@ class TournamentFullDerefEndpoint(APITestCase):
                 "players_per_team": 1,
                 "substitute_players_per_team": 0,
                 "team_per_match": 2,
-                "game_processor": None
+                "game_processor": "None"
             },
             "name": "Test Tournament",
             "rules": "have fun!",

--- a/insalan/tournament/test/test_game_processor.py
+++ b/insalan/tournament/test/test_game_processor.py
@@ -1,0 +1,616 @@
+"""GameProcessor Module Tests"""
+
+from datetime import date
+from unittest.mock import Mock, patch
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from insalan.tournament.models import (
+    Event,
+    EventTournament,
+    Game,
+    Team,
+    Player,
+    BestofType,
+    MatchStatus,
+)
+from insalan.tournament.models.bracket import Bracket, KnockoutMatch
+from insalan.tournament.models.group import Group, GroupMatch
+from insalan.tournament.models.swiss import SwissRound, SwissMatch
+from insalan.tournament.models.game_processor import (
+    EmptyGameProcessor,
+    LeagueOfLegendsGameProcessor,
+    get_processor,
+    get_processor_choices,
+    get_processor_default_parameters,
+    get_processor_parameters_schema,
+)
+from insalan.user.models import User
+
+
+class EmptyGameProcessorTestCase(TestCase):
+    """Test the EmptyGameProcessor class"""
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def setUp(self, mock_post: Mock) -> None:
+        """Set up test data"""
+        # Mock API responses to prevent actual calls during tournament creation
+        mock_response = Mock()
+        mock_response.status_code = 500  # Simulate failure so no api_data is set
+        mock_post.return_value = mock_response
+
+        event = Event.objects.create(
+            name="Test Event",
+            date_start=date(2023, 3, 1),
+            date_end=date(2023, 3, 2),
+            description="Test Description"
+        )
+        game = Game.objects.create(
+            name="Test Game",
+            game_processor="None"
+        )
+        self.tournament = EventTournament.objects.create(
+            name="Test Tournament",
+            game=game,
+            event=event,
+            max_team_thresholds=[8, 16, 32]
+        )
+        self.bracket = Bracket.objects.create(
+            tournament=self.tournament,
+            name="Test Bracket"
+        )
+        self.match = KnockoutMatch.objects.create(
+            bracket=self.bracket,
+            bo_type=BestofType.BO3,
+            round_number=1,
+            index_in_round=1
+        )
+
+    def test_empty_processor_exists(self) -> None:
+        """Test that the EmptyGameProcessor is registered"""
+        choices = get_processor_choices()
+        self.assertIn(("None", "Pas de gestion automatique"), choices)
+
+    def test_empty_processor_initialize_tournament(self) -> None:
+        """Test that initialize_tournament returns empty dict"""
+        result = EmptyGameProcessor.initialize_tournament(self.tournament)
+        self.assertEqual(result, {})
+
+    def test_empty_processor_update_tournament(self) -> None:
+        """Test that update_tournament returns empty dict"""
+        result = EmptyGameProcessor.update_tournament(self.tournament)
+        self.assertEqual(result, {})
+
+    def test_empty_processor_create_match(self) -> None:
+        """Test that create_match returns empty dict"""
+        result = EmptyGameProcessor.create_match(self.match)
+        self.assertEqual(result, {})
+
+    def test_empty_processor_start_match(self) -> None:
+        """Test that start_match returns empty dict"""
+        result = EmptyGameProcessor.start_match(self.match)
+        self.assertEqual(result, {})
+
+    def test_empty_processor_process_result_match(self) -> None:
+        """Test that process_result_match returns empty dict"""
+        result = EmptyGameProcessor.process_result_match(self.match, {})
+        self.assertEqual(result, {})
+
+    def test_empty_processor_delete_match(self) -> None:
+        """Test that delete_match doesn't raise errors"""
+        EmptyGameProcessor.delete_match(self.match)
+
+
+class LeagueOfLegendsGameProcessorTestCase(TestCase):
+    """Test the LeagueOfLegendsGameProcessor class"""
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def setUp(self, mock_post: Mock) -> None:
+        """Set up test data"""
+        # Mock API responses to prevent actual calls during tournament creation
+        mock_response = Mock()
+        mock_response.status_code = 500  # Simulate failure so no api_data is set
+        mock_post.return_value = mock_response
+
+        event = Event.objects.create(
+            name="Test Event",
+            date_start=date(2023, 3, 1),
+            date_end=date(2023, 3, 2),
+            description="Test Description"
+        )
+        self.game = Game.objects.create(
+            name="League of Legends",
+            game_processor="LoL",
+            players_per_team=5,
+            games_parameters={
+                "mapType": "SUMMONERS_RIFT",
+                "pickType": "TOURNAMENT_DRAFT",
+                "spectatorType": "ALL",
+            }
+        )
+        self.tournament = EventTournament.objects.create(
+            name="LoL Tournament",
+            game=self.game,
+            event=event,
+            max_team_thresholds=[8, 16, 32]
+        )
+
+        # Create teams with players
+        self.team1 = Team.objects.create(
+            name="Team 1",
+            tournament=self.tournament
+        )
+        self.team2 = Team.objects.create(
+            name="Team 2",
+            tournament=self.tournament
+        )
+
+        # Create users and players for team 1
+        for i in range(5):
+            user = User.objects.create(
+                username=f"player1_{i}",
+                email=f"player1_{i}@example.com"
+            )
+            Player.objects.create(
+                user=user,
+                team=self.team1,
+                name_in_game=f"Player1_{i}",
+                validator_data={"puuid": f"puuid_team1_{i}"}
+            )
+
+        # Create users and players for team 2
+        for i in range(5):
+            user = User.objects.create(
+                username=f"player2_{i}",
+                email=f"player2_{i}@example.com"
+            )
+            Player.objects.create(
+                user=user,
+                team=self.team2,
+                name_in_game=f"Player2_{i}",
+                validator_data={"puuid": f"puuid_team2_{i}"}
+            )
+
+        self.bracket = Bracket.objects.create(
+            tournament=self.tournament,
+            name="Test Bracket"
+        )
+        self.match = KnockoutMatch.objects.create(
+            bracket=self.bracket,
+            bo_type=BestofType.BO3,
+            round_number=1,
+            index_in_round=1
+        )
+        self.match.teams.add(self.team1, self.team2)
+
+    def test_lol_processor_exists(self) -> None:
+        """Test that the LeagueOfLegendsGameProcessor is registered"""
+        choices = get_processor_choices()
+        self.assertIn(("LoL", "League of Legends"), choices)
+
+    def test_lol_processor_default_parameters(self) -> None:
+        """Test that default parameters are correctly defined"""
+        defaults = get_processor_default_parameters("LoL")
+        self.assertEqual(defaults["mapType"], "SUMMONERS_RIFT")
+        self.assertEqual(defaults["pickType"], "TOURNAMENT_DRAFT")
+        self.assertEqual(defaults["spectatorType"], "ALL")
+
+    def test_lol_processor_parameters_schema(self) -> None:
+        """Test that parameters schema is correctly defined"""
+        schema = get_processor_parameters_schema("LoL")
+        self.assertIn("pickType", schema)
+        self.assertIn("mapType", schema)
+        self.assertIn("spectatorType", schema)
+        self.assertEqual(schema["pickType"]["type"], "choice")
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def test_initialize_tournament_success(self, mock_post: Mock) -> None:
+        """Test successful tournament initialization"""
+        # Mock provider creation
+        mock_provider_response = Mock()
+        mock_provider_response.status_code = 200
+        mock_provider_response.json.return_value = 12345
+
+        # Mock tournament creation
+        mock_tournament_response = Mock()
+        mock_tournament_response.status_code = 200
+        mock_tournament_response.json.return_value = 67890
+
+        mock_post.side_effect = [mock_provider_response, mock_tournament_response]
+
+        result = LeagueOfLegendsGameProcessor.initialize_tournament(self.tournament)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["providerID"], 12345)
+        self.assertEqual(result["tournamentID"], 67890)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def test_initialize_tournament_provider_failure(self, mock_post: Mock) -> None:
+        """Test tournament initialization failure on provider creation"""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_post.return_value = mock_response
+
+        result = LeagueOfLegendsGameProcessor.initialize_tournament(self.tournament)
+
+        self.assertIsNone(result)
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def test_initialize_tournament_tournament_failure(self, mock_post: Mock) -> None:
+        """Test tournament initialization failure on tournament creation"""
+        mock_provider_response = Mock()
+        mock_provider_response.status_code = 200
+        mock_provider_response.json.return_value = 12345
+
+        mock_tournament_response = Mock()
+        mock_tournament_response.status_code = 500
+
+        mock_post.side_effect = [mock_provider_response, mock_tournament_response]
+
+        result = LeagueOfLegendsGameProcessor.initialize_tournament(self.tournament)
+
+        self.assertIsNone(result)
+
+    # pylint: disable=line-too-long
+    @patch('insalan.tournament.models.game_processor.LeagueOfLegendsGameProcessor.initialize_tournament')
+    def test_update_tournament_no_matches(self, mock_initialize: Mock) -> None:
+        """Test tournament update when no matches exist"""
+        # Delete the match created in setUp to test the "no matches" scenario
+        self.match.delete()
+
+        mock_initialize.return_value = {"providerID": 12345, "tournamentID": 67890}
+
+        result = LeagueOfLegendsGameProcessor.update_tournament(self.tournament)
+
+        self.assertIsNotNone(result)
+        mock_initialize.assert_called_once_with(self.tournament)
+
+    def test_update_tournament_with_bracket_matches(self) -> None:
+        """Test tournament update fails when bracket matches exist"""
+        # Match already exists from setUp
+        with self.assertRaises(ValidationError):
+            LeagueOfLegendsGameProcessor.update_tournament(self.tournament)
+
+    def test_update_tournament_with_group_matches(self) -> None:
+        """Test tournament update fails when group matches exist"""
+        group = Group.objects.create(
+            tournament=self.tournament,
+            name="Test Group"
+        )
+        GroupMatch.objects.create(
+            group=group,
+            bo_type=BestofType.BO3,
+            round_number=1,
+            index_in_round=1
+        )
+
+        with self.assertRaises(ValidationError):
+            LeagueOfLegendsGameProcessor.update_tournament(self.tournament)
+
+    def test_update_tournament_with_swiss_matches(self) -> None:
+        """Test tournament update fails when swiss matches exist"""
+        swiss_round = SwissRound.objects.create(
+            tournament=self.tournament,
+            min_score=3
+        )
+        SwissMatch.objects.create(
+            swiss=swiss_round,
+            bo_type=BestofType.BO3,
+            round_number=1,
+            index_in_round=1
+        )
+
+        with self.assertRaises(ValidationError):
+            LeagueOfLegendsGameProcessor.update_tournament(self.tournament)
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def test_create_match_knockout(self, mock_post: Mock) -> None:
+        """Test creating a knockout match with tournament codes"""
+        self.tournament.api_data = {
+            "providerID": 12345,
+            "tournamentID": 67890
+        }
+        self.tournament.save()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ["CODE1", "CODE2", "CODE3"]
+        mock_post.return_value = mock_response
+
+        result = LeagueOfLegendsGameProcessor.create_match(self.match)
+
+        self.assertIsNotNone(result)
+        self.assertIn("pregame", result)
+        self.assertIn("postgame", result)
+        self.assertEqual(result["pregame"], ["CODE1", "CODE2", "CODE3"])
+        self.assertEqual(result["postgame"], {})
+
+    def test_create_match_no_tournament_data(self) -> None:
+        """Test creating match when tournament has no API data"""
+        # Ensure tournament has no api_data or has api_data without tournamentID
+        self.tournament.api_data = {}
+        self.tournament.save()
+
+        result = LeagueOfLegendsGameProcessor.create_match(self.match)
+
+        self.assertEqual(result, {})
+
+    def test_create_match_ranking(self) -> None:
+        """Test creating a ranking match (no codes needed)"""
+        self.match.bo_type = BestofType.RANKING
+        self.match.save()
+
+        result = LeagueOfLegendsGameProcessor.create_match(self.match)
+
+        self.assertEqual(result, {})
+
+    @patch('insalan.tournament.models.game_processor.requests.post')
+    def test_create_match_group(self, mock_post: Mock) -> None:
+        """Test creating a group match"""
+        group = Group.objects.create(
+            tournament=self.tournament,
+            name="Test Group"
+        )
+        group_match = GroupMatch.objects.create(
+            group=group,
+            bo_type=BestofType.BO5,
+            round_number=1,
+            index_in_round=1
+        )
+        group_match.teams.add(self.team1, self.team2)
+
+        self.tournament.api_data = {
+            "providerID": 12345,
+            "tournamentID": 67890
+        }
+        self.tournament.save()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = ["CODE1", "CODE2", "CODE3", "CODE4", "CODE5"]
+        mock_post.return_value = mock_response
+
+        result = LeagueOfLegendsGameProcessor.create_match(group_match)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result["pregame"]), 5)
+
+    def test_start_match(self) -> None:
+        """Test starting a match"""
+        self.match.api_data = {"pregame": ["CODE1", "CODE2", "CODE3"], "postgame": {}}
+        self.match.save()
+
+        result = LeagueOfLegendsGameProcessor.start_match(self.match)
+
+        self.assertEqual(result, self.match.api_data)
+
+    @patch('insalan.tournament.models.game_processor.requests.get')
+    def test_process_result_match_single_game(self, mock_get: Mock) -> None:
+        """Test processing a single game result"""
+        self.match.api_data = {
+            "pregame": ["CODE1", "CODE2", "CODE3"],
+            "postgame": {}
+        }
+        self.match.save()
+
+        # Mock Riot API match details response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {
+                "gameDuration": 1800,
+                "teams": [
+                    {"teamId": 100, "win": True},
+                    {"teamId": 200, "win": False}
+                ],
+                "participants": [
+                    {"teamId": 100, "puuid": "puuid_team1_0"},
+                    {"teamId": 100, "puuid": "puuid_team1_1"},
+                    {"teamId": 100, "puuid": "puuid_team1_2"},
+                    {"teamId": 100, "puuid": "puuid_team1_3"},
+                    {"teamId": 100, "puuid": "puuid_team1_4"},
+                    {"teamId": 200, "puuid": "puuid_team2_0"},
+                    {"teamId": 200, "puuid": "puuid_team2_1"},
+                    {"teamId": 200, "puuid": "puuid_team2_2"},
+                    {"teamId": 200, "puuid": "puuid_team2_3"},
+                    {"teamId": 200, "puuid": "puuid_team2_4"},
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        payload = {
+            "shortCode": "CODE1",
+            "gameId": 1234567890,
+            "startTime": 1234567890000
+        }
+
+        result = LeagueOfLegendsGameProcessor.process_result_match(self.match, payload)
+
+        self.assertIsNotNone(result)
+        self.assertIn("CODE1", result["postgame"])
+        self.assertEqual(result["postgame"]["CODE1"]["gameId"], "EUW1_1234567890")
+
+    @patch('insalan.tournament.models.game_processor.requests.get')
+    @patch('insalan.tournament.manage.match.update_match_score')
+    def test_process_result_match_all_games_finished(
+        self,
+        mock_update_score: Mock,
+        mock_get: Mock
+    ) -> None:
+        """Test processing results when all games are finished"""
+        self.match.api_data = {
+            "pregame": ["CODE1", "CODE2", "CODE3"],
+            "postgame": {
+                "CODE1": {
+                    "gameId": "EUW1_1",
+                    "gameDuration": 1800,
+                    "teams": [
+                        {"teamId": 100, "win": True},
+                        {"teamId": 200, "win": False}
+                    ],
+                    "participants": [
+                        {"teamId": 100, "puuid": "puuid_team1_0"},
+                        {"teamId": 100, "puuid": "puuid_team1_1"},
+                        {"teamId": 100, "puuid": "puuid_team1_2"},
+                        {"teamId": 100, "puuid": "puuid_team1_3"},
+                        {"teamId": 100, "puuid": "puuid_team1_4"},
+                        {"teamId": 200, "puuid": "puuid_team2_0"},
+                        {"teamId": 200, "puuid": "puuid_team2_1"},
+                        {"teamId": 200, "puuid": "puuid_team2_2"},
+                        {"teamId": 200, "puuid": "puuid_team2_3"},
+                        {"teamId": 200, "puuid": "puuid_team2_4"},
+                    ]
+                },
+                "CODE2": {
+                    "gameId": "EUW1_2",
+                    "gameDuration": 2100,
+                    "teams": [
+                        {"teamId": 100, "win": True},
+                        {"teamId": 200, "win": False}
+                    ],
+                    "participants": [
+                        {"teamId": 100, "puuid": "puuid_team1_0"},
+                        {"teamId": 100, "puuid": "puuid_team1_1"},
+                        {"teamId": 100, "puuid": "puuid_team1_2"},
+                        {"teamId": 100, "puuid": "puuid_team1_3"},
+                        {"teamId": 100, "puuid": "puuid_team1_4"},
+                        {"teamId": 200, "puuid": "puuid_team2_0"},
+                        {"teamId": 200, "puuid": "puuid_team2_1"},
+                        {"teamId": 200, "puuid": "puuid_team2_2"},
+                        {"teamId": 200, "puuid": "puuid_team2_3"},
+                        {"teamId": 200, "puuid": "puuid_team2_4"},
+                    ]
+                }
+            }
+        }
+        self.match.status = MatchStatus.ONGOING
+        self.match.save()
+
+        # Mock the final game result
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "info": {
+                "gameDuration": 1500,
+                "teams": [
+                    {"teamId": 100, "win": False},
+                    {"teamId": 200, "win": True}
+                ],
+                "participants": [
+                    {"teamId": 100, "puuid": "puuid_team1_0"},
+                    {"teamId": 100, "puuid": "puuid_team1_1"},
+                    {"teamId": 100, "puuid": "puuid_team1_2"},
+                    {"teamId": 100, "puuid": "puuid_team1_3"},
+                    {"teamId": 100, "puuid": "puuid_team1_4"},
+                    {"teamId": 200, "puuid": "puuid_team2_0"},
+                    {"teamId": 200, "puuid": "puuid_team2_1"},
+                    {"teamId": 200, "puuid": "puuid_team2_2"},
+                    {"teamId": 200, "puuid": "puuid_team2_3"},
+                    {"teamId": 200, "puuid": "puuid_team2_4"},
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        payload = {
+            "shortCode": "CODE3",
+            "gameId": 3,
+            "startTime": 1234567890000
+        }
+
+        result = LeagueOfLegendsGameProcessor.process_result_match(self.match, payload)
+
+        self.assertIsNotNone(result)
+        # Verify that update_match_score was called
+        mock_update_score.assert_called_once()
+        call_args = mock_update_score.call_args
+        self.assertEqual(call_args[0][0], self.match)
+        score_data = call_args[0][1]
+        self.assertIn("score", score_data)
+        self.assertIn("times", score_data)
+
+    def test_process_result_match_no_short_code(self) -> None:
+        """Test processing result with missing shortCode"""
+        self.match.api_data = {"pregame": ["CODE1"], "postgame": {}}
+        self.match.save()
+
+        result = LeagueOfLegendsGameProcessor.process_result_match(
+            self.match,
+            {"gameId": 123}
+        )
+
+        self.assertIsNone(result)
+
+    @patch('insalan.tournament.models.game_processor.requests.get')
+    def test_process_result_match_api_failure(self, mock_get: Mock) -> None:
+        """Test processing result when Riot API fails"""
+        self.match.api_data = {"pregame": ["CODE1"], "postgame": {}}
+        self.match.save()
+
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        result = LeagueOfLegendsGameProcessor.process_result_match(
+            self.match,
+            {"shortCode": "CODE1", "gameId": 123}
+        )
+
+        self.assertIsNone(result)
+
+    def test_delete_match(self) -> None:
+        """Test deleting a match"""
+        # Should not raise any errors
+        LeagueOfLegendsGameProcessor.delete_match(self.match)
+
+
+class ProcessorUtilityFunctionsTestCase(TestCase):
+    """Test utility functions for game processors"""
+
+    def test_get_processor_choices(self) -> None:
+        """Test getting processor choices"""
+        choices = get_processor_choices()
+        self.assertIsInstance(choices, list)
+        self.assertGreaterEqual(len(choices), 2)
+        self.assertIn(("None", "Pas de gestion automatique"), choices)
+        self.assertIn(("LoL", "League of Legends"), choices)
+
+    def test_get_processor_existing(self) -> None:
+        """Test getting an existing processor"""
+        processor = get_processor("LoL")
+        self.assertIsNotNone(processor)
+        self.assertEqual(processor, LeagueOfLegendsGameProcessor)
+
+    def test_get_processor_non_existing(self) -> None:
+        """Test getting a non-existing processor"""
+        processor = get_processor("InvalidProcessor")
+        self.assertIsNone(processor)
+
+    def test_get_processor_default_parameters_existing(self) -> None:
+        """Test getting default parameters for existing processor"""
+        params = get_processor_default_parameters("LoL")
+        self.assertIsInstance(params, dict)
+        self.assertIn("mapType", params)
+        self.assertIn("pickType", params)
+        self.assertIn("spectatorType", params)
+
+    def test_get_processor_default_parameters_non_existing(self) -> None:
+        """Test getting default parameters for non-existing processor"""
+        params = get_processor_default_parameters("InvalidProcessor")
+        self.assertEqual(params, {})
+
+    def test_get_processor_parameters_schema_existing(self) -> None:
+        """Test getting parameters schema for existing processor"""
+        schema = get_processor_parameters_schema("LoL")
+        self.assertIsInstance(schema, dict)
+        self.assertIn("mapType", schema)
+        self.assertIn("pickType", schema)
+        self.assertIn("spectatorType", schema)
+
+    def test_get_processor_parameters_schema_non_existing(self) -> None:
+        """Test getting parameters schema for non-existing processor"""
+        schema = get_processor_parameters_schema("InvalidProcessor")
+        self.assertEqual(schema, {})

--- a/insalan/tournament/test/test_game_processor.py
+++ b/insalan/tournament/test/test_game_processor.py
@@ -32,13 +32,8 @@ from insalan.user.models import User
 class EmptyGameProcessorTestCase(TestCase):
     """Test the EmptyGameProcessor class"""
 
-    @patch('insalan.tournament.models.game_processor.requests.post')
-    def setUp(self, mock_post: Mock) -> None:
+    def setUp(self) -> None:
         """Set up test data"""
-        # Mock API responses to prevent actual calls during tournament creation
-        mock_response = Mock()
-        mock_response.status_code = 500  # Simulate failure so no api_data is set
-        mock_post.return_value = mock_response
 
         event = Event.objects.create(
             name="Test Event",
@@ -50,12 +45,17 @@ class EmptyGameProcessorTestCase(TestCase):
             name="Test Game",
             game_processor="None"
         )
-        self.tournament = EventTournament.objects.create(
-            name="Test Tournament",
-            game=game,
-            event=event,
-            max_team_thresholds=[8, 16, 32]
-        )
+        with patch('insalan.tournament.models.game_processor.requests.post') as mock_post:
+            # Mock API responses to prevent actual calls during tournament creation
+            mock_response = Mock()
+            mock_response.status_code = 500  # Simulate failure so no api_data is set
+            mock_post.return_value = mock_response
+            self.tournament = EventTournament.objects.create(
+                name="Test Tournament",
+                game=game,
+                event=event,
+                max_team_thresholds=[8, 16, 32]
+            )
         self.bracket = Bracket.objects.create(
             tournament=self.tournament,
             name="Test Bracket"
@@ -105,13 +105,8 @@ class EmptyGameProcessorTestCase(TestCase):
 class LeagueOfLegendsGameProcessorTestCase(TestCase):
     """Test the LeagueOfLegendsGameProcessor class"""
 
-    @patch('insalan.tournament.models.game_processor.requests.post')
-    def setUp(self, mock_post: Mock) -> None:
+    def setUp(self) -> None:
         """Set up test data"""
-        # Mock API responses to prevent actual calls during tournament creation
-        mock_response = Mock()
-        mock_response.status_code = 500  # Simulate failure so no api_data is set
-        mock_post.return_value = mock_response
 
         event = Event.objects.create(
             name="Test Event",
@@ -129,12 +124,17 @@ class LeagueOfLegendsGameProcessorTestCase(TestCase):
                 "spectatorType": "ALL",
             }
         )
-        self.tournament = EventTournament.objects.create(
-            name="LoL Tournament",
-            game=self.game,
-            event=event,
-            max_team_thresholds=[8, 16, 32]
-        )
+        with patch('insalan.tournament.models.game_processor.requests.post') as mock_post:
+            # Mock API responses to prevent actual calls during tournament creation
+            mock_response = Mock()
+            mock_response.status_code = 500  # Simulate failure so no api_data is set
+            mock_post.return_value = mock_response
+            self.tournament = EventTournament.objects.create(
+                name="LoL Tournament",
+                game=self.game,
+                event=event,
+                max_team_thresholds=[8, 16, 32]
+            )
 
         # Create teams with players
         self.team1 = Team.objects.create(
@@ -222,6 +222,7 @@ class LeagueOfLegendsGameProcessorTestCase(TestCase):
         result = LeagueOfLegendsGameProcessor.initialize_tournament(self.tournament)
 
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for mypy
         self.assertEqual(result["providerID"], 12345)
         self.assertEqual(result["tournamentID"], 67890)
         self.assertEqual(mock_post.call_count, 2)
@@ -322,6 +323,7 @@ class LeagueOfLegendsGameProcessorTestCase(TestCase):
         result = LeagueOfLegendsGameProcessor.create_match(self.match)
 
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for mypy
         self.assertIn("pregame", result)
         self.assertIn("postgame", result)
         self.assertEqual(result["pregame"], ["CODE1", "CODE2", "CODE3"])
@@ -375,6 +377,7 @@ class LeagueOfLegendsGameProcessorTestCase(TestCase):
         result = LeagueOfLegendsGameProcessor.create_match(group_match)
 
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for mypy
         self.assertEqual(len(result["pregame"]), 5)
 
     def test_start_match(self) -> None:
@@ -430,6 +433,7 @@ class LeagueOfLegendsGameProcessorTestCase(TestCase):
         result = LeagueOfLegendsGameProcessor.process_result_match(self.match, payload)
 
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for mypy
         self.assertIn("CODE1", result["postgame"])
         self.assertEqual(result["postgame"]["CODE1"]["gameId"], "EUW1_1234567890")
 

--- a/insalan/tournament/urls.py
+++ b/insalan/tournament/urls.py
@@ -16,6 +16,11 @@ urlpatterns = [
     path("game/", views.GameList.as_view(), name="game/list"),
     path("game/<int:pk>/", views.GameDetails.as_view(), name="game/details"),
     path(
+        "game/processor-parameters/",
+        views.GameProcessorParameters.as_view(),
+        name="game/processor-parameters"
+    ),
+    path(
         "tournament/privates/",
         views.PrivateTournamentList.as_view(),
         name="private-tournament/list"
@@ -92,6 +97,11 @@ urlpatterns = [
         name="generate/tournament/swiss/round"
     ),
     path("me/", views.TournamentMe.as_view(), name="tournament/me"),
+    path(
+        "tournament/<int:pk>/result/",
+        views.TournamentResult.as_view(),
+        name="tournament/result"
+    ),
     path("team/", views.TeamList.as_view(), name="team/list"),
     path("team/seeding", views.AdminTeamSeeding.as_view(), name="team/seeding"),
     path("team/<int:pk>/", views.TeamDetails.as_view(), name="team/details"),
@@ -157,6 +167,11 @@ urlpatterns = [
         name="group/match/score"
     ),
     path(
+        "group/<int:group_id>/match/<int:match_id>/result/",
+        views.GroupMatchResult.as_view(),
+        name="group/match/result"
+    ),
+    path(
         "bracket/<int:pk>/",
         views.BracketDetails.as_view(),
         name="bracket/details"
@@ -172,6 +187,11 @@ urlpatterns = [
         name="bracket/match/score"
     ),
     path(
+        "bracket/<int:bracket_id>/match/<int:match_id>/result/",
+        views.BracketMatchResult.as_view(),
+        name="bracket/match/result"
+    ),
+    path(
         "swiss/<int:swiss_id>/match/<int:match_id>/",
         views.SwissMatchPatch.as_view(),
         name="swiss/match"
@@ -180,5 +200,10 @@ urlpatterns = [
         "swiss/<int:swiss_id>/match/<int:match_id>/score/",
         views.SwissMatchScore.as_view(),
         name="swiss/match/score"
+    ),
+    path(
+        "swiss/<int:swiss_id>/match/<int:match_id>/result/",
+        views.SwissMatchResult.as_view(),
+        name="swiss/match/result"
     ),
 ]

--- a/insalan/tournament/views/bracket.py
+++ b/insalan/tournament/views/bracket.py
@@ -28,6 +28,7 @@ from ..manage import (
     update_match_score,
     update_next_knockout_match,
 )
+from ..models.game_processor import get_processor
 from .permissions import ReadOnly
 
 
@@ -210,4 +211,79 @@ class BracketMatchScore(generics.GenericAPIView[KnockoutMatch]):
         return Response(
             status=status.HTTP_200_OK,
             data=serializer.data
+        )
+
+
+class BracketMatchResult(generics.GenericAPIView[KnockoutMatch]):  # pylint: disable=unsubscriptable-object
+    """Process match result from external API callback (e.g., Riot Games)"""
+
+    queryset = KnockoutMatch.objects.all().order_by("id")
+    serializer_class = serializers.KnockoutMatchSerializer
+    permission_classes = [permissions.AllowAny]  # Allow external API callbacks
+    lookup_url_kwarg = "match_id"
+
+    # The decorator is missing types stubs.
+    @swagger_auto_schema(  # type: ignore[misc]
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            description=_("Payload from external API callback")
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "status": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Status message")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Match not found")
+                    )
+                }
+            ),
+        },
+    )
+    def post(self, request: Request, bracket_id: int, match_id: int) -> Response:
+        """Process the result payload from an external API"""
+        try:
+            match = KnockoutMatch.objects.get(id=match_id, bracket_id=bracket_id)
+        except KnockoutMatch.DoesNotExist:
+            return Response(
+                {"err": _("Match introuvable")},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get the game processor for this match's tournament
+        tournament = match.bracket.tournament
+        game = tournament.game
+        processor_class = get_processor(game.game_processor)
+
+        if processor_class is None:
+            return Response(
+                {"err": _("Aucun processeur de jeu configuré")},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Process the result using the game processor
+        payload = request.data
+        result_data = processor_class.process_result_match(match, payload)
+
+        if result_data is not None:
+            match.api_data = result_data
+            match.save(update_fields=["api_data"])
+
+            return Response(
+                {"status": _("Résultat traité avec succès")},
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {"err": _("Échec du traitement du résultat")},
+            status=status.HTTP_400_BAD_REQUEST
         )

--- a/insalan/tournament/views/game.py
+++ b/insalan/tournament/views/game.py
@@ -12,6 +12,10 @@ from rest_framework.response import Response
 from insalan.tournament import serializers
 
 from ..models import Game
+from ..models.game_processor import (
+    get_processor_default_parameters,
+    get_processor_parameters_schema,
+)
 from .permissions import ReadOnly
 
 class GameList(generics.ListCreateAPIView[Game]):  # pylint: disable=unsubscriptable-object
@@ -187,3 +191,80 @@ class GameDetails(generics.RetrieveUpdateDestroyAPIView[Game]):
         Partially update a game
         """
         return super().patch(request, *args, **kwargs)
+
+
+class GameProcessorParameters(generics.GenericAPIView[Game]):  # pylint: disable=unsubscriptable-object
+    """Get the default parameters and schema for a game processor"""
+
+    permission_classes = [permissions.IsAdminUser | ReadOnly]
+
+    # The decorator is missing types stubs.
+    @swagger_auto_schema(  # type: ignore[misc]
+        manual_parameters=[
+            openapi.Parameter(
+                "processor",
+                openapi.IN_QUERY,
+                description=_("Le nom court du processeur de jeu (ex: 'LoL', 'None')"),
+                type=openapi.TYPE_STRING,
+                required=True
+            )
+        ],
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "default_parameters": openapi.Schema(
+                        type=openapi.TYPE_OBJECT,
+                        description=_("Paramètres par défaut pour ce processeur")
+                    ),
+                    "parameters_schema": openapi.Schema(
+                        type=openapi.TYPE_OBJECT,
+                        description=_("Schéma des paramètres disponibles")
+                    )
+                }
+            ),
+            400: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Paramètre 'processor' manquant")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Processeur non trouvé")
+                    )
+                }
+            )
+        }
+    )
+    def get(self, request: Request) -> Response:
+        """
+        Get default parameters and schema for a game processor
+        """
+        processor_name = request.query_params.get("processor")
+        
+        if not processor_name:
+            return Response(
+                {"err": _("Le paramètre 'processor' est requis")},
+                status=400
+            )
+        
+        default_params = get_processor_default_parameters(processor_name)
+        schema = get_processor_parameters_schema(processor_name)
+        
+        if not default_params and not schema:
+            return Response(
+                {"err": _("Processeur non trouvé ou sans paramètres")},
+                status=404
+            )
+        
+        return Response({
+            "default_parameters": default_params,
+            "parameters_schema": schema
+        })

--- a/insalan/tournament/views/game.py
+++ b/insalan/tournament/views/game.py
@@ -248,22 +248,22 @@ class GameProcessorParameters(generics.GenericAPIView[Game]):  # pylint: disable
         Get default parameters and schema for a game processor
         """
         processor_name = request.query_params.get("processor")
-        
+
         if not processor_name:
             return Response(
                 {"err": _("Le paramètre 'processor' est requis")},
                 status=400
             )
-        
+
         default_params = get_processor_default_parameters(processor_name)
         schema = get_processor_parameters_schema(processor_name)
-        
+
         if not default_params and not schema:
             return Response(
                 {"err": _("Processeur non trouvé ou sans paramètres")},
                 status=404
             )
-        
+
         return Response({
             "default_parameters": default_params,
             "parameters_schema": schema

--- a/insalan/tournament/views/group.py
+++ b/insalan/tournament/views/group.py
@@ -16,6 +16,7 @@ from insalan.user.models import User
 
 from ..models import Group, validate_match_data, GroupMatch, MatchStatus, BaseTournament
 from ..manage import update_match_score, generate_groups, create_group_matchs, launch_match
+from ..models.game_processor import get_processor
 
 from .permissions import ReadOnly
 
@@ -257,4 +258,79 @@ class GroupMatchScore(generics.UpdateAPIView[GroupMatch]):  # pylint: disable=un
         return Response(
             status=status.HTTP_200_OK,
             data=serializer.data
+        )
+
+
+class GroupMatchResult(generics.GenericAPIView[GroupMatch]):  # pylint: disable=unsubscriptable-object
+    """Process match result from external API callback (e.g., Riot Games)"""
+
+    queryset = GroupMatch.objects.all().order_by("id")
+    serializer_class = serializers.GroupMatchSerializer
+    permission_classes = [permissions.AllowAny]  # Allow external API callbacks
+    lookup_url_kwarg = "match_id"
+
+    # The decorator is missing types stubs.
+    @swagger_auto_schema(  # type: ignore[misc]
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            description=_("Payload from external API callback")
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "status": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Status message")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Match not found")
+                    )
+                }
+            ),
+        },
+    )
+    def post(self, request: Request, group_id: int, match_id: int) -> Response:
+        """Process the result payload from an external API"""
+        try:
+            match = GroupMatch.objects.get(id=match_id, group_id=group_id)
+        except GroupMatch.DoesNotExist:
+            return Response(
+                {"err": _("Match introuvable")},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get the game processor for this match's tournament
+        tournament = match.group.tournament
+        game = tournament.game
+        processor_class = get_processor(game.game_processor)
+
+        if processor_class is None:
+            return Response(
+                {"err": _("Aucun processeur de jeu configuré")},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Process the result using the game processor
+        payload = request.data
+        result_data = processor_class.process_result_match(match, payload)
+
+        if result_data is not None:
+            match.api_data = result_data
+            match.save(update_fields=["api_data"])
+
+            return Response(
+                {"status": _("Résultat traité avec succès")},
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {"err": _("Échec du traitement du résultat")},
+            status=status.HTTP_400_BAD_REQUEST
         )

--- a/insalan/tournament/views/swiss.py
+++ b/insalan/tournament/views/swiss.py
@@ -20,7 +20,10 @@ from ..manage import (
     launch_match,
     update_match_score,
 )
-from ..models import MatchStatus, BaseTournament, SwissMatch, validate_match_data
+from ..models import MatchStatus, BaseTournament, SwissMatch, validate_match_data, SwissRound
+from ..models.game_processor import get_processor
+
+from .permissions import ReadOnly
 
 
 # pylint: disable-next=unsubscriptable-object
@@ -204,4 +207,79 @@ class SwissMatchScore(generics.GenericAPIView[SwissMatch]):
         return Response(
             status=status.HTTP_200_OK,
             data=serializer.data
+        )
+
+
+class SwissMatchResult(generics.GenericAPIView[SwissMatch]):  # pylint: disable=unsubscriptable-object
+    """Process match result from external API callback (e.g., Riot Games)"""
+
+    queryset = SwissMatch.objects.all().order_by("id")
+    serializer_class = serializers.SwissMatchSerializer
+    permission_classes = [permissions.AllowAny]  # Allow external API callbacks
+    lookup_url_kwarg = "match_id"
+
+    # The decorator is missing types stubs.
+    @swagger_auto_schema(  # type: ignore[misc]
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            description=_("Payload from external API callback")
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "status": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Status message")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Match not found")
+                    )
+                }
+            ),
+        },
+    )
+    def post(self, request: Request, swiss_id: int, match_id: int) -> Response:
+        """Process the result payload from an external API"""
+        try:
+            match = SwissMatch.objects.get(id=match_id, round_id=swiss_id)
+        except SwissMatch.DoesNotExist:
+            return Response(
+                {"err": _("Match introuvable")},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get the game processor for this match's tournament
+        tournament = match.round.tournament
+        game = tournament.game
+        processor_class = get_processor(game.game_processor)
+
+        if processor_class is None:
+            return Response(
+                {"err": _("Aucun processeur de jeu configuré")},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Process the result using the game processor
+        payload = request.data
+        result_data = processor_class.process_result_match(match, payload)
+
+        if result_data is not None:
+            match.api_data = result_data
+            match.save(update_fields=["api_data"])
+
+            return Response(
+                {"status": _("Résultat traité avec succès")},
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {"err": _("Échec du traitement du résultat")},
+            status=status.HTTP_400_BAD_REQUEST
         )

--- a/insalan/tournament/views/swiss.py
+++ b/insalan/tournament/views/swiss.py
@@ -20,11 +20,8 @@ from ..manage import (
     launch_match,
     update_match_score,
 )
-from ..models import MatchStatus, BaseTournament, SwissMatch, validate_match_data, SwissRound
+from ..models import MatchStatus, BaseTournament, SwissMatch, validate_match_data
 from ..models.game_processor import get_processor
-
-from .permissions import ReadOnly
-
 
 # pylint: disable-next=unsubscriptable-object
 class CreateSwissRounds(generics.CreateAPIView[BaseTournament]):
@@ -248,7 +245,7 @@ class SwissMatchResult(generics.GenericAPIView[SwissMatch]):  # pylint: disable=
     def post(self, request: Request, swiss_id: int, match_id: int) -> Response:
         """Process the result payload from an external API"""
         try:
-            match = SwissMatch.objects.get(id=match_id, round_id=swiss_id)
+            match = SwissMatch.objects.get(id=match_id, swiss_id=swiss_id)
         except SwissMatch.DoesNotExist:
             return Response(
                 {"err": _("Match introuvable")},
@@ -256,7 +253,7 @@ class SwissMatchResult(generics.GenericAPIView[SwissMatch]):  # pylint: disable=
             )
 
         # Get the game processor for this match's tournament
-        tournament = match.round.tournament
+        tournament = match.swiss.tournament
         game = tournament.game
         processor_class = get_processor(game.game_processor)
 

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -30,6 +30,7 @@ from ..models import (
     KnockoutMatch,
     SwissMatch,
 )
+from ..models.game_processor import get_processor
 from .permissions import ReadOnly
 
 
@@ -600,3 +601,123 @@ class TournamentMe(generics.RetrieveAPIView[Any]):  # pylint: disable=unsubscrip
             "substitute": substitutes,
             "ongoing_match": ongoing_match,
         }, status=status.HTTP_200_OK)
+
+
+class TournamentResult(generics.GenericAPIView[EventTournament]):  # pylint: disable=unsubscriptable-object
+    """Process match result from external API callback for any match in a tournament"""
+
+    queryset = EventTournament.objects.all().order_by("id")
+    serializer_class = serializers.EventTournamentSerializer
+    permission_classes = [permissions.AllowAny]  # Allow external API callbacks
+
+    # The decorator is missing types stubs.
+    @swagger_auto_schema(  # type: ignore[misc]
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            description=_("Payload from external API callback")
+        ),
+        responses={
+            200: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "status": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Status message")
+                    )
+                }
+            ),
+            404: openapi.Schema(
+                type=openapi.TYPE_OBJECT,
+                properties={
+                    "err": openapi.Schema(
+                        type=openapi.TYPE_STRING,
+                        description=_("Tournament or match not found")
+                    )
+                }
+            ),
+        },
+    )
+    def post(self, request: Request, pk: int) -> Response:
+        """Process the result payload from an external API
+        
+        This endpoint is called by external APIs (like Riot Games) with match results.
+        It finds the appropriate match and processes the result using the game processor.
+        """
+        try:
+            tournament = EventTournament.objects.get(id=pk)
+        except EventTournament.DoesNotExist:
+            return Response(
+                {"err": _("Tournoi introuvable")},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get the game processor for this tournament
+        game = tournament.game
+        processor_class = get_processor(game.game_processor)
+
+        if processor_class is None:
+            return Response(
+                {"err": _("Aucun processeur de jeu configuré")},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        payload = request.data
+        
+        # Extract the short code from payload to find the match
+        short_code = payload.get("shortCode")
+        
+        if not short_code:
+            return Response(
+                {"err": _("Code de tournoi manquant dans le payload")},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Find the match with this tournament code in its api_data
+        # Check all match types: GroupMatch, KnockoutMatch, SwissMatch
+        match = None
+        
+        # Search in group matches
+        for group_match in GroupMatch.objects.filter(group__tournament=tournament):
+            pregame_codes = group_match.api_data.get("pregame", []) if group_match.api_data else []
+            if short_code in pregame_codes:
+                match = group_match
+                break
+        
+        # Search in bracket matches
+        if match is None:
+            for knockout_match in KnockoutMatch.objects.filter(bracket__tournament=tournament):
+                pregame_codes = knockout_match.api_data.get("pregame", []) if knockout_match.api_data else []
+                if short_code in pregame_codes:
+                    match = knockout_match
+                    break
+        
+        # Search in swiss matches
+        if match is None:
+            for swiss_match in SwissMatch.objects.filter(round__tournament=tournament):
+                pregame_codes = swiss_match.api_data.get("pregame", []) if swiss_match.api_data else []
+                if short_code in pregame_codes:
+                    match = swiss_match
+                    break
+        
+        if match is None:
+            return Response(
+                {"err": _("Aucun match trouvé avec ce code de tournoi")},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Process the result using the game processor
+        result_data = processor_class.process_result_match(match, payload)
+
+        if result_data is not None:
+            match.api_data = result_data
+            match.save(update_fields=["api_data"])
+
+            return Response(
+                {"status": _("Résultat traité avec succès")},
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {"err": _("Échec du traitement du résultat")},
+            status=status.HTTP_400_BAD_REQUEST
+        )

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -662,10 +662,10 @@ class TournamentResult(generics.GenericAPIView[EventTournament]):  # pylint: dis
             )
 
         payload = request.data
-        
+
         # Extract the short code from payload to find the match
         short_code = payload.get("shortCode")
-        
+
         if not short_code:
             return Response(
                 {"err": _("Code de tournoi manquant dans le payload")},
@@ -674,31 +674,37 @@ class TournamentResult(generics.GenericAPIView[EventTournament]):  # pylint: dis
 
         # Find the match with this tournament code in its api_data
         # Check all match types: GroupMatch, KnockoutMatch, SwissMatch
-        match = None
-        
+        match: GroupMatch | KnockoutMatch | SwissMatch | None = None
+
         # Search in group matches
         for group_match in GroupMatch.objects.filter(group__tournament=tournament):
             pregame_codes = group_match.api_data.get("pregame", []) if group_match.api_data else []
             if short_code in pregame_codes:
                 match = group_match
                 break
-        
+
         # Search in bracket matches
         if match is None:
             for knockout_match in KnockoutMatch.objects.filter(bracket__tournament=tournament):
-                pregame_codes = knockout_match.api_data.get("pregame", []) if knockout_match.api_data else []
+                if knockout_match.api_data:
+                    pregame_codes = knockout_match.api_data.get("pregame", [])
+                else:
+                    pregame_codes = []
                 if short_code in pregame_codes:
                     match = knockout_match
                     break
-        
+
         # Search in swiss matches
         if match is None:
-            for swiss_match in SwissMatch.objects.filter(round__tournament=tournament):
-                pregame_codes = swiss_match.api_data.get("pregame", []) if swiss_match.api_data else []
+            for swiss_match in SwissMatch.objects.filter(swiss__tournament=tournament):
+                if swiss_match.api_data:
+                    pregame_codes = swiss_match.api_data.get("pregame", [])
+                else:
+                    pregame_codes = []
                 if short_code in pregame_codes:
                     match = swiss_match
                     break
-        
+
         if match is None:
             return Response(
                 {"err": _("Aucun match trouvé avec ce code de tournoi")},

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -650,8 +650,8 @@ class TournamentResult(generics.GenericAPIView[EventTournament]):  # pylint: dis
         It finds the appropriate match and processes the result using the game processor.
         """
         try:
-            tournament = EventTournament.objects.get(id=pk)
-        except EventTournament.DoesNotExist:
+            tournament = BaseTournament.objects.get(id=pk)
+        except BaseTournament.DoesNotExist:
             return Response(
                 {"err": _("Tournoi introuvable")},
                 status=status.HTTP_404_NOT_FOUND

--- a/insalan/tournament/views/tournament.py
+++ b/insalan/tournament/views/tournament.py
@@ -489,6 +489,12 @@ class TournamentMe(generics.RetrieveAPIView[Any]):  # pylint: disable=unsubscrip
             del ongoing_match["times"]
             del ongoing_match["status"]
 
+            # Add game info to ongoing_match
+            ongoing_match["game"] = serializers.GameSerializer(
+                ongoing_matchs[0].get_tournament().get_game(),
+                context={"request": request},
+            ).data
+
             team_list = {}
             for team in ongoing_match["teams"]:
                 team_list[str(team)] = Team.objects.get(pk=team).get_name()


### PR DESCRIPTION
## Description

Allow our tournament pipeline to automatically gather end game stats through game-specific processors that integrate with external APIs (e.g., Riot Games API for League of Legends).

### Additions :
- Add `GameProcessor` abstract base class with 6 lifecycle methods (initialize_tournament, update_tournament, create_match, start_match, process_result_match, delete_match)
- Add `EmptyGameProcessor` (no-op default implementation for games without automation)
- Add `LeagueOfLegendsGameProcessor` with full Riot Tournament API v5 integration
- Add `api_data` JSONField to Tournament, Match models for storing API responses (readonly in admin panel)
- Add `games_parameters` JSONField to Game model to store processor configuration
- Add `game_processor` field to Game model with processor selection
- Add API endpoints for result callbacks:
  - `POST /api/tournament/{id}/result/` - Tournament-level callback
  - `POST /api/tournament/group/{group_id}/match/{match_id}/result/` - Group match callback
  - `POST /api/tournament/bracket/{bracket_id}/match/{match_id}/result/` - Bracket match callback
  - `POST /api/tournament/swiss/{swiss_id}/match/{match_id}/result/` - Swiss match callback
- Add `GET /api/tournament/game/processor-parameters/?processor=LoL` endpoint for fetching processor configuration schemas
- Determine match winner from ingame data and propagate the result (start next matchs)
- Integrate processor calls throughout tournament/match lifecycle:
  - Tournament creation -> `initialize_tournament()`
  - Match creation -> `create_match()`
  - Match launch -> `start_match()`
  - Match deletion -> `delete_match()`
- Add admin action "Rafraîchir les données API du tournoi" to refresh tournament API data
- Add admin action "Réinitialiser aux paramètres par défaut" to reset game parameters to default values
- Add custom `GameParametersWidget` for rendering game parameters as individual form fields (select, checkbox, text, number) instead of raw JSON
- Add default parameters system with schema validation (type, choices, label, help_text)

### TODO :
- Test complete LoL tournament flow end-to-end in a mini to be sure
- Select only few fields from post game to reduce db size

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.


## Related Issues

Fix #234 

## Screenshots

<img width="2505" height="1257" alt="image" src="https://github.com/user-attachments/assets/c13afaa2-4862-4d17-bdb0-d6e742d3ee8e" />
<img width="949" height="110" alt="image" src="https://github.com/user-attachments/assets/1c026656-bc9a-4034-b853-b4f90bf02ef2" />

