### PR TITLE
Add tests for is_staff and is_admin for the langate endpoint

### DIFF
--- a/docs/manuel/src/03-existant/modules/langate.md
+++ b/docs/manuel/src/03-existant/modules/langate.md
@@ -6,7 +6,7 @@ l'événement.
 
 ## Qu'est-ce qu'un Langate et pourquoi s'infliger cela ?
 
-Le [*Langate2000*](https://github.com/InsaLan/langate2000) ou Langate est le
+Le [*Langate3000*](https://github.com/InsaLan/langate3000) ou Langate est le
 portail captif utilisé par l'InsaLan lors des événements (Mini ou autre) pour
 authentifier les utilisateur⋅ices. Cela permet deux choses importantes:
  - N'autoriser l'accès au réseau qu'aux personnes ayant payé leur entrée
@@ -20,7 +20,7 @@ authentifier les utilisateur⋅ices. Cela permet deux choses importantes:
 Ainsi, le Langate tourne localement dans l'infrastructure de Cœur de Réseau
 (CdR) pour filtrer l'accès à Internet et gérer les authentifications.
 
-Lors des Minis (du moins jusqu'en 2023), le Bureau se chargeait de créer les
+Lors des Minis (du moins jusqu'en 2026), le Bureau se chargeait de créer les
 comptes autorisés sur le Langate lors du paiement d'une entrée. Lors des
 événements, cependant, pour simplifier la vie de tout le monde, les comptes ne
 sont pas créés manuellement. À la place, le Langate interroge le site web de
@@ -38,14 +38,20 @@ point d'API.
 
 ## Le Fonctionnement
 
-Le point d'API utilisé est `/v1/langate/authenticate` en verbe `POST`. Le Langate doit `POST` avec un objet au format JSON qui contient le nom d'utilisateur et le mot de passe. Par exemple:
+Le point d'API utilisé est `/v1/langate/authenticate` en verbe `POST`. Le
+Langate doit `POST` avec un objet au format JSON qui contient le nom
+d'utilisateur et le mot de passe. Par exemple:
+
 ```json
 {
   "username": "theUser",
   "password": "thePassword",
 }
 ```
-Le site web va alors faire une tentative de connexion avec ces informations. En cas de succès, la réponse sera un objet JSON qui contient les informations nécessaires pour créer un compte sur le Langate. En cas d'échec, la réponse sera un objet JSON qui contient une erreur.
+Le site web va alors faire une tentative de connexion avec ces informations. En
+cas de succès, la réponse sera un objet JSON qui contient les informations
+nécessaires pour créer un compte sur le Langate. En cas d'échec, la réponse sera
+un objet JSON qui contient une erreur.
 
 ### Réponse
 
@@ -59,7 +65,8 @@ Le backend répond un objet JSON qui décrit:
      une en tant que joueur et une en tant que manager, la liste est forcément
      limitée en taille. Chaque entrée dans la liste contient:
      - Le nom de code du jeu du tournois (par exemple: `"CSGO"`)
-     - Le nom complet du jeu: (par exemple: `"Counter-Strike: Global Offensive"`)
+     - Le nom complet du jeu: (par exemple:
+         `"Counter-Strike: Global Offensive"`)
      - Le numéro identifiant de la Team pour laquelle la place est enregistrée
      - Un booléen qui décrit si la place concerne un⋅e joueur⋅euse, ou un⋅e
          manager

--- a/insalan/langate/tests.py
+++ b/insalan/langate/tests.py
@@ -439,3 +439,75 @@ class EndpointTests(APITestCase):
         self.assertEqual(tourney_reg["team"], "Bloop")
         self.assertTrue(tourney_reg["manager"])
         self.assertTrue(tourney_reg["has_paid"])
+
+    def test_is_staff_and_is_admin_true(self) -> None:
+        """
+        Authenticate a staff admin user and ensure is_staff and is_admin are
+        True in the response.
+        """
+        Event.objects.create(
+            name="Insalan XX",
+            date_start=date(2026, 3, 6),
+            date_end=date(2026, 3, 8),
+            ongoing=True
+        )
+        User.objects.create_user(
+            username="admin",
+            email="admin@insalan.fr",
+            first_name="Admin",
+            last_name="Root",
+            password="password",
+            is_staff=True,
+            is_superuser=True,
+        )
+
+        data = {
+            "username": "admin",
+            "password": "password",
+        }
+        reply = self.client.post('/v1/langate/authenticate/', data)
+        self.assertEqual(reply.status_code, 404)
+
+        user = reply.data["user"]
+        self.assertEqual(user["username"], "admin")
+        self.assertEqual(user["email"], "admin@insalan.fr")
+        self.assertEqual(user["first_name"], "Admin")
+        self.assertEqual(user["last_name"], "Root")
+        self.assertTrue(user["is_staff"])
+        self.assertTrue(user["is_admin"])
+
+    def test_is_staff_and_is_admin_false(self) -> None:
+        """
+        Authenticate a regular user and ensure is_staff and is_admin are False
+        in the response.
+        """
+        Event.objects.create(
+            name="Insalan XX",
+            date_start=date(2026, 3, 6),
+            date_end=date(2026, 3, 8),
+            ongoing=True
+        )
+        User.objects.create_user(
+            username="limefox",
+            email="test@example.com",
+            first_name="Lux Amelia",
+            last_name="Phifollen",
+            password="password",
+            is_staff=False,
+            is_superuser=False,
+        )
+
+        data = {
+            "username": "limefox",
+            "password": "password",
+        }
+        reply = self.client.post('/v1/langate/authenticate/', data)
+        self.assertEqual(reply.status_code, 404)
+
+        user = reply.data["user"]
+        self.assertEqual(user["username"], "limefox")
+        self.assertEqual(user["email"], "test@example.com")
+        self.assertEqual(user["first_name"], "Lux Amelia")
+        self.assertEqual(user["last_name"], "Phifollen")
+        self.assertFalse(user["is_staff"])
+        self.assertFalse(user["is_admin"])


### PR DESCRIPTION
## Description

Add tests to ensure that is_staff and is_admin flag are correctly passed by the langate authenticate endpoint.
 
## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

Fix #137 