### PR TITLE
Partial round robin

### DIFF
--- a/insalan/tournament/manage/group.py
+++ b/insalan/tournament/manage/group.py
@@ -19,7 +19,8 @@ def generate_groups(
     team_per_group: int,
     names: list[str],
     use_seeding: bool,
-    stage: Stage
+    stage: Stage,
+    round_count: int
 ) -> None:
     teams: list[Team | None]
     if use_seeding:
@@ -40,7 +41,7 @@ def generate_groups(
         group = Group.objects.create(
             tournament=tournament,
             name=names[i],
-            round_count=team_per_group - 1,
+            round_count=round_count,
             stage=stage
         )
 

--- a/insalan/tournament/models/group.py
+++ b/insalan/tournament/models/group.py
@@ -96,8 +96,7 @@ class Group(models.Model):
         return [team for (team, _) in seeded_teams + non_seeded_teams]
 
     def get_round_count(self) -> int:
-        team_per_match = self.tournament.game.team_per_match  # pylint: disable=no-member
-        return ceil(len(self.get_teams_id()) / team_per_match) * team_per_match - 1
+        return self.round_count
 
     def get_leaderboard(self) -> dict[int, int]:
         leaderboard = {}

--- a/insalan/tournament/models/group.py
+++ b/insalan/tournament/models/group.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from math import ceil
 from operator import itemgetter
 from typing import TYPE_CHECKING
 

--- a/insalan/tournament/serializers.py
+++ b/insalan/tournament/serializers.py
@@ -254,6 +254,7 @@ class GroupsCreateSerializer(serializers.Serializer[Any]):
     names = serializers.ListField()
     use_seeding = serializers.BooleanField()
     auto_fill = serializers.BooleanField()
+    round_count = serializers.IntegerField(min_value=1, allow_null=True)
 
     def validate(self, data: Any) -> Any:
         tournament: BaseTournament = data["tournament"]
@@ -301,6 +302,7 @@ class GroupsMatchsCreateSerializer(serializers.Serializer[Any]):
     )
     bo_type = serializers.ChoiceField(BestofType)
     play_all = serializers.BooleanField()
+    round_count = serializers.IntegerField(min_value=1)
 
     def validate_groups(self, value: list[Group]) -> Any:
         if len(set(g.tournament.id for g in value)) != 1:

--- a/insalan/tournament/views/group.py
+++ b/insalan/tournament/views/group.py
@@ -93,6 +93,10 @@ class GroupsMatchsCreate(generics.CreateAPIView[Any]):
         data.is_valid(raise_exception=True)
 
         for group in data.validated_data["groups"]:
+            if group.round_count != data.validated_data["round_count"]:
+                group.round_count = data.validated_data["round_count"]
+                group.save()
+
             create_group_matchs(
                 group,
                 data.validated_data["bo_type"],

--- a/insalan/tournament/views/stage.py
+++ b/insalan/tournament/views/stage.py
@@ -54,6 +54,10 @@ class StageAddGroups(generics.CreateAPIView[Stage]):
         data = self.get_serializer(data=request.data)
         data.is_valid(raise_exception=True)
 
+        if data.validated_data["round_count"] is None:
+            team_per_group = data.validated_data["team_per_group"]
+            data.validated_data["round_count"] = team_per_group - 1
+
         auto_fill = data.validated_data.pop("auto_fill")
         if auto_fill:
             generate_groups(**data.validated_data, stage=stage)

--- a/insalan/tournament/views/stage.py
+++ b/insalan/tournament/views/stage.py
@@ -66,7 +66,7 @@ class StageAddGroups(generics.CreateAPIView[Stage]):
                 Group.objects.create(
                     tournament=data.validated_data["tournament"],
                     name=data.validated_data["names"][i],
-                    round_count=data.validated_data["round_count"],
+                    round_count=data.validated_data["round_count"], #type: ignore
                     stage=stage
                 )
 


### PR DESCRIPTION
## Description

Add the option to use a user defined number of rounds for a group round robin instead of a computed one based on the number teams.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.


## Related Issues

See #165

