### PR TITLE
Prevent email update if it already exist in database

### DIFF
--- a/insalan/user/views.py
+++ b/insalan/user/views.py
@@ -212,6 +212,13 @@ class UserMe(generics.RetrieveAPIView[User]):  # pylint: disable=unsubscriptable
 
         if "email" in data:
             user.email = UserManager.normalize_email(data["email"])
+            try:
+                user.validate_unique()
+            except ValidationError as err:
+                return Response(
+                    {"user": err.messages},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
             mailer = MailManager.get_mailer(EMAIL_AUTH["contact"]["from"])
             assert mailer is not None
             mailer.send_email_confirmation(user)


### PR DESCRIPTION
## Description

Add a validation to only invalidate and update user email if it doesn't already exist in the database. This will prevent account locking.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.


## Related Issues

Fix #245

